### PR TITLE
Update dois

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@ hs_err_pid*
 RemoteSystemsTempFiles
 
 update-dois/target/maven-status/maven-compiler-plugin/compile/default-compile/*.lst
-update-dois/.settings/org.eclipse.jdt.core.prefs 
+update-dois/.settings/org.eclipse.jdt.core.prefs
 config.properties
 *.classpath
 *.project
+*.report

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
@@ -28,7 +28,8 @@ public class UpdateDOIs {
 
     MySQLAdaptor testReactomeDBA = null;
     MySQLAdaptor gkCentralDBA = null;
-    long authorId = 0;
+    long authorIdTR = 0;
+    long authorIdGK = 0;
 
     try {
       Properties props = new Properties();
@@ -40,7 +41,9 @@ public class UpdateDOIs {
       String databaseTR = props.getProperty("databaseTR");
       String databaseGk = props.getProperty("databaseGK");
       int port = Integer.valueOf(props.getProperty("port"));
-      authorId = Integer.valueOf(props.getProperty("authorId"));
+      authorIdTR = Integer.valueOf(props.getProperty("authorIdTR"));
+      authorIdGK = Integer.valueOf(props.getProperty("authorIdGK"));
+      
 
       // Set up db connections.
       testReactomeDBA = new MySQLAdaptor(host, databaseTR, user, password, port);
@@ -53,7 +56,7 @@ public class UpdateDOIs {
       findNewDOIsAndUpdate.setTestReactomeAdaptor(testReactomeDBA);
       findNewDOIsAndUpdate.setGkCentralAdaptor(gkCentralDBA);
 
-      findNewDOIsAndUpdate.findAndUpdateDOIs(authorId, pathToReport);
+      findNewDOIsAndUpdate.findAndUpdateDOIs(authorIdTR, authorIdGK, pathToReport);
       
       logger.info( "UpdateDOIs Complete" );
     }

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
@@ -14,15 +14,17 @@ public class UpdateDOIs {
   public static void main( String[] args ) {
 
     String pathToConfig = "src/main/resources/config.properties";
+    String pathToReport = "src/main/resources/UpdateDOIs.report";
     
     if (args.length > 0 && !args[0].equals("")) {
       pathToConfig = args[0];
+      pathToReport = args[1];
     }
 
-    UpdateDOIs.executeUpdateDOIs(pathToConfig);
+    UpdateDOIs.executeUpdateDOIs(pathToConfig, pathToReport);
   }
 
-  public static void executeUpdateDOIs(String pathToResources) {
+  public static void executeUpdateDOIs(String pathToResources, String pathToReport) {
 
     MySQLAdaptor testReactomeDBA = null;
     MySQLAdaptor gkCentralDBA = null;
@@ -51,7 +53,7 @@ public class UpdateDOIs {
       findNewDOIsAndUpdate.setTestReactomeAdaptor(testReactomeDBA);
       findNewDOIsAndUpdate.setGkCentralAdaptor(gkCentralDBA);
 
-      findNewDOIsAndUpdate.findNewDOIsAndUpdate(authorId);
+      findNewDOIsAndUpdate.findAndUpdateDOIs(authorId, pathToReport);
       
       logger.info( "UpdateDOIs Complete" );
     }

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/findNewDOIsAndUpdate.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/findNewDOIsAndUpdate.java
@@ -33,7 +33,6 @@ public class findNewDOIsAndUpdate {
     this.dbaGkCentral = adaptor;
   }
 
-  @SuppressWarnings({"unchecked","rawtypes"})
   public void findAndUpdateDOIs(long authorIdTR, long authorIdGK, String pathToReport) {
 
     Collection<GKInstance> dois;
@@ -43,23 +42,22 @@ public class findNewDOIsAndUpdate {
 	GKInstance instanceEditTestReactome = this.createInstanceEdit(this.dbaTestReactome, authorIdTR, creatorFile);
 	GKInstance instanceEditGkCentral = this.createInstanceEdit(this.dbaGkCentral, authorIdGK, creatorFile);
 
-    HashMap reportContents = this.getReportContents(pathToReport);
+    HashMap<String,String> reportContents = this.getReportContents(pathToReport);
     int reportHits = 0;
     int fetchHits = 0;
-    ArrayList updatedDOIs = new ArrayList();
+    ArrayList<String> updatedDOIs = new ArrayList<String>();
     try {
 
       dois = this.dbaTestReactome.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180");
-      dois = this.dbaTestReactome.fetchInstanceByAttribute("Pathway", "DB_ID", "REGEXP", "8939211|9006115|9018678|9033241");
 
       if (!dois.isEmpty()) {
         for (GKInstance doi : dois) {
-        	
+
           String stableIdFromDb = ((GKInstance) doi.getAttributeValue("stableIdentifier")).getDisplayName();
           String nameFromDb = doi.getAttributeValue("name").toString();
           String updatedDoi = "10.3180/" + stableIdFromDb;
           String dbId = doi.getAttributeValue("DB_ID").toString();
-          
+
           // Used to verify that report contents are as expected, based on provided list form curators
           fetchHits++;
           updatedDOIs.add(updatedDoi);
@@ -67,7 +65,7 @@ public class findNewDOIsAndUpdate {
           {
         	  reportHits++;
           }
-          
+
           // This updates the 'modified' field for Pathways, keeping track of when changes happened.
           doi.getAttributeValuesList("modified");
           doi.addAttributeValue("modified", instanceEditTestReactome);
@@ -79,13 +77,13 @@ public class findNewDOIsAndUpdate {
           gkdois = this.dbaGkCentral.fetchInstanceByAttribute("Pathway", "DB_ID", "=", dbId);
           if (!gkdois.isEmpty()) {
             for (GKInstance gkdoi : gkdois) {
-            	
+
               gkdoi.getAttributeValuesList("modified");
-              gkdoi.addAttributeValue("modified", instanceEditGkCentral);      
-              gkdoi.setAttributeValue("doi", updatedDoi);	
+              gkdoi.addAttributeValue("modified", instanceEditGkCentral);
+              gkdoi.setAttributeValue("doi", updatedDoi);
               this.dbaGkCentral.updateInstanceAttribute(doi, "modified");
               this.dbaGkCentral.updateInstanceAttribute(gkdoi, "doi");
-              
+
               logger.info("Updated DOI: " + updatedDoi + " for " + nameFromDb);
             }
           } else {
@@ -125,10 +123,9 @@ public class findNewDOIsAndUpdate {
   }
 
   // Parses input report and places each line's contents in HashMap
-  @SuppressWarnings("rawtypes")
-  public HashMap getReportContents(String pathToReport) {
+  public HashMap<String,String> getReportContents(String pathToReport) {
 
-	HashMap reportContents = new HashMap();
+	HashMap<String,String> reportContents = new HashMap<String,String>();
 	try {
 	  	FileReader fr = new FileReader(pathToReport);
 	  	BufferedReader br = new BufferedReader(fr);

--- a/update-dois/src/test/java/org/reactome/release/updateDOIs/TestUpdateDOIs.java
+++ b/update-dois/src/test/java/org/reactome/release/updateDOIs/TestUpdateDOIs.java
@@ -50,7 +50,7 @@ public class TestUpdateDOIs {
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180")).thenReturn(testResults);
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "DB_ID", "=", "67890")).thenReturn(testResults);
 		
-		check.findNewDOIsAndUpdate(12345L);
+		check.findAndUpdateDOIs(12345L,"reportPath");
     }
 	
 	@Test
@@ -63,7 +63,7 @@ public class TestUpdateDOIs {
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180")).thenReturn(new ArrayList<GKInstance>());
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "DB_ID", "=", "67890")).thenReturn(new ArrayList<GKInstance>());
 		
-		check.findNewDOIsAndUpdate(12345L);
+		check.findAndUpdateDOIs(12345L,"reportPath");
 	}
 	
 	@Test
@@ -83,6 +83,6 @@ public class TestUpdateDOIs {
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180")).thenReturn(testResults);
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "DB_ID", "=", "67890")).thenReturn(new ArrayList<GKInstance>());
 		
-		check.findNewDOIsAndUpdate(12345L);
+		check.findAndUpdateDOIs(12345L,"reportPath");
 	}
 }

--- a/update-dois/src/test/java/org/reactome/release/updateDOIs/TestUpdateDOIs.java
+++ b/update-dois/src/test/java/org/reactome/release/updateDOIs/TestUpdateDOIs.java
@@ -50,7 +50,7 @@ public class TestUpdateDOIs {
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180")).thenReturn(testResults);
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "DB_ID", "=", "67890")).thenReturn(testResults);
 		
-		check.findAndUpdateDOIs(12345L,"reportPath");
+		check.findAndUpdateDOIs(12345L, 67890L, "reportPath");
     }
 	
 	@Test
@@ -63,7 +63,7 @@ public class TestUpdateDOIs {
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180")).thenReturn(new ArrayList<GKInstance>());
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "DB_ID", "=", "67890")).thenReturn(new ArrayList<GKInstance>());
 		
-		check.findAndUpdateDOIs(12345L,"reportPath");
+		check.findAndUpdateDOIs(12345L, 67890L, "reportPath");
 	}
 	
 	@Test
@@ -83,6 +83,6 @@ public class TestUpdateDOIs {
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180")).thenReturn(testResults);
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "DB_ID", "=", "67890")).thenReturn(new ArrayList<GKInstance>());
 		
-		check.findAndUpdateDOIs(12345L,"reportPath");
+		check.findAndUpdateDOIs(12345L, 67890L, "reportPath");
 	}
 }


### PR DESCRIPTION
Java Update DOIs now works more similarly to it's Perl equivalent. Two notable changes:
- It queries the DBs directly for DOI's to update, rather than iterating through the entire table
- Instance Edits now work based on Author ID, and will throw errors for any invalid IDs given (Different IDs for different DBs)