### PR TITLE
Feature/add ortho stable ids

### DIFF
--- a/orthoinference/pom.xml
+++ b/orthoinference/pom.xml
@@ -27,7 +27,25 @@
 		  <groupId>org.apache.logging.log4j</groupId>
 		  <artifactId>log4j-core</artifactId>
 		  <version>2.11.0</version>
-	</dependency>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<version>1.6.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<version>1.6.5</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<properties>

--- a/orthoinference/src/main/java/org/reactome/orthoinference/EWASInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EWASInferrer.java
@@ -58,7 +58,7 @@ public class EWASInferrer {
 
 						infReferenceGeneProductInst.addAttributeValue(species, speciesInst);
 						infReferenceGeneProductInst.setAttributeValue(_displayName, "UniProt:" + homologueId);
-						infReferenceGeneProductInst = InstanceUtilities.checkForIdenticalInstances(infReferenceGeneProductInst);
+						infReferenceGeneProductInst = InstanceUtilities.checkForIdenticalInstances(infReferenceGeneProductInst, null);
 						referenceGeneProductIdenticals.put(homologueId, infReferenceGeneProductInst);
 					} else {
 						infReferenceGeneProductInst = referenceGeneProductIdenticals.get(homologueId);
@@ -159,7 +159,7 @@ public class EWASInferrer {
 						if (residueIdenticals.get(cacheKey) != null) {
 							infModifiedResidueInst = residueIdenticals.get(cacheKey);
 						} else {
-							infModifiedResidueInst = InstanceUtilities.checkForIdenticalInstances(infModifiedResidueInst);
+							infModifiedResidueInst = InstanceUtilities.checkForIdenticalInstances(infModifiedResidueInst, null);
 							residueIdenticals.put(cacheKey, infModifiedResidueInst);
 						}
 						infModifiedResidueInstances.add((GKInstance) infModifiedResidueInst);
@@ -170,7 +170,7 @@ public class EWASInferrer {
 					if (ewasIdenticals.get(cacheKey) != null) {
 						infEWASInst = ewasIdenticals.get(cacheKey);
 					} else {
-						infEWASInst = InstanceUtilities.checkForIdenticalInstances(infEWASInst);
+						infEWASInst = InstanceUtilities.checkForIdenticalInstances(infEWASInst, ewasInst);
 						ewasIdenticals.put(cacheKey, infEWASInst);
 					}
 
@@ -208,7 +208,7 @@ public class EWASInferrer {
 			referenceDNAInst.addAttributeValue(referenceDatabase, ensgDbInst);
 			referenceDNAInst.addAttributeValue(species, speciesInst);
 			referenceDNAInst.setAttributeValue(_displayName, "ENSEMBL:" + ensgId);
-			referenceDNAInst = InstanceUtilities.checkForIdenticalInstances(referenceDNAInst);
+			referenceDNAInst = InstanceUtilities.checkForIdenticalInstances(referenceDNAInst, null);
 			referenceDNAInstances.add(referenceDNAInst);
 			if (altRefDbExists)
 			{
@@ -224,7 +224,7 @@ public class EWASInferrer {
 				alternateRefDNAInst.addAttributeValue(referenceDatabase, alternateDbInst);
 				alternateRefDNAInst.addAttributeValue(species, speciesInst);
 				alternateRefDNAInst.setAttributeValue(_displayName, alternateDbInst.getAttributeValue(name) + ":" + ensgId);
-				alternateRefDNAInst = InstanceUtilities.checkForIdenticalInstances(alternateRefDNAInst);
+				alternateRefDNAInst = InstanceUtilities.checkForIdenticalInstances(alternateRefDNAInst, null);
 				referenceDNAInstances.add(alternateRefDNAInst);
 			}
 		}
@@ -326,7 +326,7 @@ public class EWASInferrer {
 		alternateDbInst.addAttributeValue(url, altRefDbJSON.get("url"));
 		alternateDbInst.addAttributeValue(accessUrl, altRefDbJSON.get("access"));
 		alternateDbInst.setAttributeValue(_displayName, ((JSONArray) altRefDbJSON.get("dbname")).get(0));
-		alternateDbInst = InstanceUtilities.checkForIdenticalInstances(alternateDbInst);
+		alternateDbInst = InstanceUtilities.checkForIdenticalInstances(alternateDbInst, null);
 		if (altRefDbJSON.get("alt_id") != null)
 		{
 			altRefDbId = (String) altRefDbJSON.get("alt_id");

--- a/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -103,6 +103,7 @@ public class EventsInferrer
 		inferredFile.createNewFile();
 		ReactionInferrer.setEligibleFilename(eligibleFilename);
 		ReactionInferrer.setInferredFilename(inferredFilename);
+		StableIdentifierGenerator.setSpeciesAbbreviation((String) speciesObject.get("abbreviation"));
 
 		// Set static variables (DB/Species Instances, mapping files) that will be repeatedly used
 		setInstanceEdits(personId);
@@ -236,6 +237,7 @@ public class EventsInferrer
 		SkipInstanceChecker.setAdaptor(dbAdaptor);
 		InstanceUtilities.setAdaptor(dbAdaptor);
 		OrthologousEntityGenerator.setAdaptor(dbAdaptor);
+		StableIdentifierGenerator.setAdaptor(dbAdaptor);
 		EWASInferrer.setAdaptor(dbAdaptor);
 		HumanEventsUpdater.setAdaptor(dbAdaptor);
 		
@@ -312,6 +314,7 @@ public class EventsInferrer
 		instanceEditInst = InstanceEditUtils.createInstanceEdit(dbAdaptor, personId, "org.reactome.orthoinference");
 		InstanceUtilities.setInstanceEdit(instanceEditInst);
 		OrthologousEntityGenerator.setInstanceEdit(instanceEditInst);
+		StableIdentifierGenerator.setInstanceEdit(instanceEditInst);
 		EWASInferrer.setInstanceEdit(instanceEditInst);
 		HumanEventsUpdater.setInstanceEdit(instanceEditInst);
 	}

--- a/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -191,6 +191,7 @@ public class EventsInferrer
 				return;
 			} catch (Exception e) {
 				e.printStackTrace();
+				return;
 			}
 		}
 		HumanEventsUpdater.setInferredEvent(ReactionInferrer.getInferredEvent());

--- a/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -272,7 +272,7 @@ public class EventsInferrer
 		speciesInst.addAttributeValue(created, instanceEditInst);
 		speciesInst.addAttributeValue(name, toSpeciesLong);
 		speciesInst.addAttributeValue(_displayName, toSpeciesLong);
-		speciesInst = InstanceUtilities.checkForIdenticalInstances(speciesInst);
+		speciesInst = InstanceUtilities.checkForIdenticalInstances(speciesInst, null);
 		logger.info("Species instance is " + speciesInst);
 		OrthologousEntityGenerator.setSpeciesInstance(speciesInst);
 		EWASInferrer.setSpeciesInstance(speciesInst);
@@ -287,7 +287,7 @@ public class EventsInferrer
 		String summationText = "This event has been computationally inferred from an event that has been demonstrated in another species.<p>The inference is based on the homology mapping from PANTHER. Briefly, reactions for which all involved PhysicalEntities (in input, output and catalyst) have a mapped orthologue/paralogue (for complexes at least 75% of components must have a mapping) are inferred to the other species. High level events are also inferred for these events to allow for easier navigation.<p><a href='/electronic_inference_compara.html' target = 'NEW'>More details and caveats of the event inference in Reactome.</a> For details on PANTHER see also: <a href='http://www.pantherdb.org/about.jsp' target='NEW'>http://www.pantherdb.org/about.jsp</a>";
 		summationInst.addAttributeValue(text, summationText);
 		summationInst.addAttributeValue(_displayName, summationText);
-		summationInst = InstanceUtilities.checkForIdenticalInstances(summationInst);
+		summationInst = InstanceUtilities.checkForIdenticalInstances(summationInst, null);
 		
 		ReactionInferrer.setSummationInstance(summationInst);
 		HumanEventsUpdater.setSummationInstance(summationInst);
@@ -302,7 +302,7 @@ public class EventsInferrer
 		evidenceTypeInst.addAttributeValue(name, evidenceTypeText);
 		evidenceTypeInst.addAttributeValue(name, "IEA");
 		evidenceTypeInst.addAttributeValue(_displayName, evidenceTypeText);
-		evidenceTypeInst = InstanceUtilities.checkForIdenticalInstances(evidenceTypeInst);
+		evidenceTypeInst = InstanceUtilities.checkForIdenticalInstances(evidenceTypeInst, null);
 		ReactionInferrer.setEvidenceTypeInstance(evidenceTypeInst);
 		HumanEventsUpdater.setEvidenceTypeInstance(evidenceTypeInst);
 	}

--- a/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -186,9 +186,6 @@ public class EventsInferrer
 			try {
 				logger.info("Attempting to infer " + reactionInst);
 				ReactionInferrer.inferReaction(reactionInst);
-			} catch (RuntimeException e) {
-				e.printStackTrace();
-				return;
 			} catch (Exception e) {
 				e.printStackTrace();
 				return;

--- a/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -50,6 +50,7 @@ public class EventsInferrer
 	private static GKInstance speciesInst;
 	private static Map<GKInstance,GKInstance> manualEventToNonHumanSource = new HashMap<GKInstance,GKInstance>();
 	private static List<GKInstance> manualHumanEvents = new ArrayList<GKInstance>();
+	private static StableIdentifierGenerator stableIdentifierGenerator;
 
 	@SuppressWarnings("unchecked")
 	public static void inferEvents(Properties props, String pathToConfig, String species) throws Exception
@@ -103,7 +104,9 @@ public class EventsInferrer
 		inferredFile.createNewFile();
 		ReactionInferrer.setEligibleFilename(eligibleFilename);
 		ReactionInferrer.setInferredFilename(inferredFilename);
-		StableIdentifierGenerator.setSpeciesAbbreviation((String) speciesObject.get("abbreviation"));
+
+
+		stableIdentifierGenerator = new StableIdentifierGenerator(dbAdaptor, (String) speciesObject.get("abbreviation"));
 
 		// Set static variables (DB/Species Instances, mapping files) that will be repeatedly used
 		setInstanceEdits(personId);
@@ -183,6 +186,9 @@ public class EventsInferrer
 			try {
 				logger.info("Attempting to infer " + reactionInst);
 				ReactionInferrer.inferReaction(reactionInst);
+			} catch (RuntimeException e) {
+				e.printStackTrace();
+				return;
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
@@ -193,6 +199,10 @@ public class EventsInferrer
 		resetVariables();
 		System.gc();
 		logger.info("Finished orthoinference of " + speciesName + ".");
+	}
+
+	public static StableIdentifierGenerator getStableIdentifierGenerator() {
+		return stableIdentifierGenerator;
 	}
 
 	private static void setReleaseDates(String dateOfRelease) 
@@ -237,7 +247,6 @@ public class EventsInferrer
 		SkipInstanceChecker.setAdaptor(dbAdaptor);
 		InstanceUtilities.setAdaptor(dbAdaptor);
 		OrthologousEntityGenerator.setAdaptor(dbAdaptor);
-		StableIdentifierGenerator.setAdaptor(dbAdaptor);
 		EWASInferrer.setAdaptor(dbAdaptor);
 		HumanEventsUpdater.setAdaptor(dbAdaptor);
 		
@@ -314,7 +323,6 @@ public class EventsInferrer
 		instanceEditInst = InstanceEditUtils.createInstanceEdit(dbAdaptor, personId, "org.reactome.orthoinference");
 		InstanceUtilities.setInstanceEdit(instanceEditInst);
 		OrthologousEntityGenerator.setInstanceEdit(instanceEditInst);
-		StableIdentifierGenerator.setInstanceEdit(instanceEditInst);
 		EWASInferrer.setInstanceEdit(instanceEditInst);
 		HumanEventsUpdater.setInstanceEdit(instanceEditInst);
 	}

--- a/orthoinference/src/main/java/org/reactome/orthoinference/HumanEventsUpdater.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/HumanEventsUpdater.java
@@ -138,6 +138,7 @@ public class HumanEventsUpdater {
 					}
 					infHasEventReferralInst.setDisplayName(hasEventReferralInst.getDisplayName());
 					inferredEventIdenticals.put(hasEventReferralInst, infHasEventReferralInst);
+					StableIdentifierGenerator.generateOrthologousStableId(infHasEventReferralInst, hasEventReferralInst);
 					dba.storeInstance(infHasEventReferralInst);
 					
 					// This was replaced with addAttributeValueIfNecessary due to a bug where a Pathway instance's 'OrthologousEvent' attribute was being replaced,

--- a/orthoinference/src/main/java/org/reactome/orthoinference/HumanEventsUpdater.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/HumanEventsUpdater.java
@@ -138,7 +138,7 @@ public class HumanEventsUpdater {
 					}
 					infHasEventReferralInst.setDisplayName(hasEventReferralInst.getDisplayName());
 					inferredEventIdenticals.put(hasEventReferralInst, infHasEventReferralInst);
-					StableIdentifierGenerator.generateOrthologousStableId(infHasEventReferralInst, hasEventReferralInst);
+					infHasEventReferralInst = StableIdentifierGenerator.generateOrthologousStableId(infHasEventReferralInst, hasEventReferralInst);
 					dba.storeInstance(infHasEventReferralInst);
 					
 					// This was replaced with addAttributeValueIfNecessary due to a bug where a Pathway instance's 'OrthologousEvent' attribute was being replaced,

--- a/orthoinference/src/main/java/org/reactome/orthoinference/HumanEventsUpdater.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/HumanEventsUpdater.java
@@ -138,7 +138,7 @@ public class HumanEventsUpdater {
 					}
 					infHasEventReferralInst.setDisplayName(hasEventReferralInst.getDisplayName());
 					inferredEventIdenticals.put(hasEventReferralInst, infHasEventReferralInst);
-					infHasEventReferralInst = StableIdentifierGenerator.generateOrthologousStableId(infHasEventReferralInst, hasEventReferralInst);
+					infHasEventReferralInst = EventsInferrer.getStableIdentifierGenerator().generateOrthologousStableId(infHasEventReferralInst, hasEventReferralInst);
 					dba.storeInstance(infHasEventReferralInst);
 					
 					// This was replaced with addAttributeValueIfNecessary due to a bug where a Pathway instance's 'OrthologousEvent' attribute was being replaced,

--- a/orthoinference/src/main/java/org/reactome/orthoinference/InstanceUtilities.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/InstanceUtilities.java
@@ -133,7 +133,7 @@ public class InstanceUtilities {
 			}
 		} else {
 			if (inferredInst.getSchemClass().isa(PhysicalEntity)) {
-				inferredInst = StableIdentifierGenerator.generateOrthologousStableId(inferredInst, originalInst);
+				inferredInst = EventsInferrer.getStableIdentifierGenerator().generateOrthologousStableId(inferredInst, originalInst);
 			}
 			dba.storeInstance(inferredInst);
 			logger.info("\tNo identical instance found -- inserting " + inferredInst);

--- a/orthoinference/src/main/java/org/reactome/orthoinference/InstanceUtilities.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/InstanceUtilities.java
@@ -82,7 +82,7 @@ public class InstanceUtilities {
 				}
 			}
 		}
-		newCompartmentInst = checkForIdenticalInstances(newCompartmentInst);
+		newCompartmentInst = checkForIdenticalInstances(newCompartmentInst, null);
 		return newCompartmentInst;
 	}
 
@@ -107,7 +107,7 @@ public class InstanceUtilities {
 		{
 			mockedInst = mockedIdenticals.get(cacheKey);
 		} else {
-			mockedInst = checkForIdenticalInstances(mockedInst);
+			mockedInst = checkForIdenticalInstances(mockedInst, instanceToBeMocked);
 			mockedIdenticals.put(cacheKey, mockedInst);
 		}
 		instanceToBeMocked = addAttributeValueIfNecessary(instanceToBeMocked, mockedInst, inferredTo);
@@ -117,7 +117,7 @@ public class InstanceUtilities {
 	}
 	
 	// Checks that equivalent instances don't already exist in the DB, substituting if they do
-	public static GKInstance checkForIdenticalInstances(GKInstance inferredInst) throws Exception
+	public static GKInstance checkForIdenticalInstances(GKInstance inferredInst, GKInstance originalInst) throws Exception
 	{
 		@SuppressWarnings("unchecked")
 		Collection<GKInstance> identicalInstances = dba.fetchIdenticalInstances(inferredInst);
@@ -132,6 +132,14 @@ public class InstanceUtilities {
 				return identicalInstances.iterator().next();
 			}
 		} else {
+			if (inferredInst.getSchemClass().isa(PhysicalEntity)) {
+				GKInstance stableIdentifierInst = (GKInstance) originalInst.getAttributeValue(stableIdentifier);
+				if (stableIdentifierInst != null) {
+					StableIdentifierGenerator.generateOrthologousStableId(inferredInst, stableIdentifierInst);
+				} else {
+					System.out.println("Null stableIdentifierInst");
+				}
+			}
 			dba.storeInstance(inferredInst);
 			logger.info("\tNo identical instance found -- inserting " + inferredInst);
 			return inferredInst;

--- a/orthoinference/src/main/java/org/reactome/orthoinference/InstanceUtilities.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/InstanceUtilities.java
@@ -133,12 +133,7 @@ public class InstanceUtilities {
 			}
 		} else {
 			if (inferredInst.getSchemClass().isa(PhysicalEntity)) {
-				GKInstance stableIdentifierInst = (GKInstance) originalInst.getAttributeValue(stableIdentifier);
-				if (stableIdentifierInst != null) {
-					StableIdentifierGenerator.generateOrthologousStableId(inferredInst, stableIdentifierInst);
-				} else {
-					System.out.println("Null stableIdentifierInst");
-				}
+				inferredInst = StableIdentifierGenerator.generateOrthologousStableId(inferredInst, originalInst);
 			}
 			dba.storeInstance(inferredInst);
 			logger.info("\tNo identical instance found -- inserting " + inferredInst);

--- a/orthoinference/src/main/java/org/reactome/orthoinference/OrthologousEntityGenerator.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/OrthologousEntityGenerator.java
@@ -145,7 +145,7 @@ public class OrthologousEntityGenerator {
 				{
 					infDefinedSetInst = definedSetIdenticals.get(cacheKey);
 				} else {
-					infDefinedSetInst = InstanceUtilities.checkForIdenticalInstances(infDefinedSetInst);
+					infDefinedSetInst = InstanceUtilities.checkForIdenticalInstances(infDefinedSetInst, ewasInst);
 					definedSetIdenticals.put(cacheKey, infDefinedSetInst);
 				}
 				infDefinedSetInst = InstanceUtilities.addAttributeValueIfNecessary(infDefinedSetInst, ewasInst, inferredFrom);
@@ -227,7 +227,7 @@ public class OrthologousEntityGenerator {
 			{
 				infComplexInst = complexIdenticals.get(cacheKey);
 			} else {
-				infComplexInst = InstanceUtilities.checkForIdenticalInstances(infComplexInst);
+				infComplexInst = InstanceUtilities.checkForIdenticalInstances(infComplexInst, complexInst);
 				complexIdenticals.put(cacheKey, infComplexInst);
 			}
 
@@ -370,7 +370,7 @@ public class OrthologousEntityGenerator {
 			{
 				infEntitySetInst = entitySetIdenticals.get(cacheKey);
 			} else {
-				infEntitySetInst = InstanceUtilities.checkForIdenticalInstances(infEntitySetInst);
+				infEntitySetInst = InstanceUtilities.checkForIdenticalInstances(infEntitySetInst, entitySetInst);
 				entitySetIdenticals.put(cacheKey, infEntitySetInst);
 			}
 			if (infEntitySetInst.getSchemClass().isValidAttribute(species) && entitySetInst.getAttributeValue(species) != null)
@@ -412,7 +412,7 @@ public class OrthologousEntityGenerator {
 		String complexSummationText = "This complex/polymer has been computationally inferred (based on PANTHER) from a complex/polymer involved in an event that has been demonstrated in another species.";
 		complexSummationInst.addAttributeValue(text, complexSummationText);
 		complexSummationInst.setAttributeValue(_displayName, complexSummationText);
-		complexSummationInst = InstanceUtilities.checkForIdenticalInstances(complexSummationInst);
+		complexSummationInst = InstanceUtilities.checkForIdenticalInstances(complexSummationInst, null);
 	}
 	
 	public static void resetVariables()

--- a/orthoinference/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
@@ -90,7 +90,7 @@ public class ReactionInferrer {
 							}
 							// FetchIdenticalInstances would just return the instance being inferred. Since this step is meant to always
 							// add a new inferred instance, the storeInstance method is just called here.
-							StableIdentifierGenerator.generateOrthologousStableId(infReactionInst, reactionInst);
+							infReactionInst = StableIdentifierGenerator.generateOrthologousStableId(infReactionInst, reactionInst);
 							dba.storeInstance(infReactionInst);
 							logger.info("\tInference complete -- " + infReactionInst + " inserted");
 							if (infReactionInst.getSchemClass().isValidAttribute(inferredFrom))
@@ -121,6 +121,7 @@ public class ReactionInferrer {
 							inferrableHumanEvents.add(reactionInst);
 							String inferredEvent = infReactionInst.getAttributeValue(DB_ID).toString() + "\t" + infReactionInst.getDisplayName() + "\n";	
 							Files.write(Paths.get(inferredFilehandle), inferredEvent.getBytes(), StandardOpenOption.APPEND);
+							logger.info("Successfully inferred " + reactionInst);
 						} else {
 							logger.info("\tCatalyst inference unsuccessful -- terminating inference for " + reactionInst);
 						}

--- a/orthoinference/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
@@ -89,7 +89,8 @@ public class ReactionInferrer {
 								infReactionInst.addAttributeValue(releaseDate, dateOfRelease);
 							}
 							// FetchIdenticalInstances would just return the instance being inferred. Since this step is meant to always
-							// add a new inferred instance, the storeInstance method is just called here. 
+							// add a new inferred instance, the storeInstance method is just called here.
+							StableIdentifierGenerator.generateOrthologousStableId(infReactionInst, reactionInst);
 							dba.storeInstance(infReactionInst);
 							logger.info("\tInference complete -- " + infReactionInst + " inserted");
 							if (infReactionInst.getSchemClass().isValidAttribute(inferredFrom))
@@ -110,7 +111,7 @@ public class ReactionInferrer {
 								logger.info("\t" + inferredRegulations.size() + " regulators inferred");
 								for (GKInstance infRegulation : inferredRegulations)
 								{
-									infRegulation = InstanceUtilities.checkForIdenticalInstances(infRegulation);
+									infRegulation = InstanceUtilities.checkForIdenticalInstances(infRegulation, null);
 									infReactionInst.addAttributeValue("regulatedBy", infRegulation);
 									dba.updateInstanceAttribute(infReactionInst, "regulatedBy");
 								}
@@ -187,7 +188,7 @@ public class ReactionInferrer {
 				}
 				infCatalystInst.addAttributeValue(activeUnit, activeUnits);
 				infCatalystInst.addAttributeValue(_displayName, catalystInst.getAttributeValue(_displayName));
-				infCatalystInst = InstanceUtilities.checkForIdenticalInstances(infCatalystInst);
+				infCatalystInst = InstanceUtilities.checkForIdenticalInstances(infCatalystInst, null);
 				inferredCatalyst.put(catalystInst, infCatalystInst);
 				infReactionInst.addAttributeValue(catalystActivity, infCatalystInst);
 			} 

--- a/orthoinference/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
@@ -90,7 +90,7 @@ public class ReactionInferrer {
 							}
 							// FetchIdenticalInstances would just return the instance being inferred. Since this step is meant to always
 							// add a new inferred instance, the storeInstance method is just called here.
-							infReactionInst = StableIdentifierGenerator.generateOrthologousStableId(infReactionInst, reactionInst);
+							infReactionInst = EventsInferrer.getStableIdentifierGenerator().generateOrthologousStableId(infReactionInst, reactionInst);
 							dba.storeInstance(infReactionInst);
 							logger.info("\tInference complete -- " + infReactionInst + " inserted");
 							if (infReactionInst.getSchemClass().isValidAttribute(inferredFrom))

--- a/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
@@ -8,6 +8,8 @@ import org.gk.persistence.MySQLAdaptor;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+
 import static org.gk.model.ReactomeJavaConstants.*;
 
 /*
@@ -40,14 +42,11 @@ public class StableIdentifierGenerator {
 
         // Paralogs will have the same base stable identifier, but we want to denote when that happens.
         // We pull the value from `seenOrthoIds`, increment it and then add it to the stable identifier name (eg: R-MMU-123456-2)
-        if (seenOrthoIds.get(targetIdentifier) == null) {
-            seenOrthoIds.put(targetIdentifier, 1);
-        } else {
-            int paralogCount = seenOrthoIds.get(targetIdentifier);
-            paralogCount++;
-            seenOrthoIds.put(targetIdentifier, paralogCount);
+        int paralogCount = Optional.ofNullable(seenOrthoIds.get(targetIdentifier)).orElse(0) + 1;
+        if (paralogCount > 1) {
             targetIdentifier += "-" + paralogCount;
         }
+        seenOrthoIds.put(targetIdentifier, paralogCount);
 
         // Check that the stable identifier instance does not already exist in DB
         // TODO: Performance check
@@ -69,7 +68,6 @@ public class StableIdentifierGenerator {
 
         // Populate inferred instance with new StableIdentifier instance
         inferredInst.addAttributeValue(stableIdentifier, orthoStableIdentifierInst);
-
         return inferredInst;
     }
 }

--- a/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
@@ -1,10 +1,66 @@
 package org.reactome.orthoinference;
 
 import org.gk.model.GKInstance;
+import org.gk.persistence.MySQLAdaptor;
 
+import java.util.HashMap;
+import java.util.Map;
+import static org.gk.model.ReactomeJavaConstants.*;
+
+/*
+ *  All PhysicalEntitys, ReactionlikeEvents and Pathways are routed to this class to generate their stable identifiers
+ */
 public class StableIdentifierGenerator {
 
-    public static void generateOrthologousStableId(GKInstance inferredInst, GKInstance stableIdentifierInst) {
+    private static MySQLAdaptor dba;
+    private static GKInstance instanceEditInst;
+    private static Map<String,Integer> seenOrthoIds = new HashMap<>();
+    private static String speciesAbbreviation = null;
 
+    public static GKInstance generateOrthologousStableId(GKInstance inferredInst, GKInstance originalInst) throws Exception {
+
+        // All Human PhysicalEntitys and Events will have a StableIdentifier instance in the stableIdentifier attribute
+        GKInstance stableIdentifierInst = (GKInstance) originalInst.getAttributeValue(stableIdentifier);
+
+        // For now, Human is hard-coded as the source species, so we replace the stableIdentifier source species based on that assumption
+        String sourceIdentifier = (String) stableIdentifierInst.getAttributeValue(identifier);
+        String targetIdentifier = sourceIdentifier.replace("HSA", speciesAbbreviation);
+        // Paralogs will have the same base stable identifier, but we want to denote when that happens.
+        // We pull the value from `seenOrthoIds`, increment it and then add it to the stable identifier name (eg: R-MMU-123456-2)
+        if (seenOrthoIds.get(targetIdentifier) == null) {
+            seenOrthoIds.put(targetIdentifier, 1);
+        } else {
+            int paralogCount = seenOrthoIds.get(targetIdentifier);
+            paralogCount++;
+            seenOrthoIds.put(targetIdentifier, paralogCount);
+            targetIdentifier += "-" + paralogCount;
+        }
+
+        // Create new StableIdentifier instance
+        GKInstance orthoStableIdentifierInst = InstanceUtilities.createNewInferredGKInstance(stableIdentifierInst);
+        orthoStableIdentifierInst.addAttributeValue(identifier, targetIdentifier);
+        String identifierVersionNumber = "1";
+        orthoStableIdentifierInst.addAttributeValue(identifierVersion, identifierVersionNumber);
+        String orthoStableIdentifierName = targetIdentifier + "." + identifierVersionNumber;
+        orthoStableIdentifierInst.setDisplayName(orthoStableIdentifierName);
+        dba.storeInstance(orthoStableIdentifierInst);
+
+        // Populate inferred instance with new StableIdentifier instance
+        inferredInst.addAttributeValue(stableIdentifier, orthoStableIdentifierInst);
+
+        return inferredInst;
+
+    }
+
+    public static void setSpeciesAbbreviation(String speciesAbbreviationCopy) {
+        speciesAbbreviation = speciesAbbreviationCopy;
+    }
+
+    public static void setInstanceEdit(GKInstance instanceEditInstCopy) {
+        instanceEditInst = instanceEditInstCopy;
+    }
+
+    public static void setAdaptor(MySQLAdaptor dbAdaptor) {
+        dba = dbAdaptor;
     }
 }

--- a/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
@@ -1,0 +1,10 @@
+package org.reactome.orthoinference;
+
+import org.gk.model.GKInstance;
+
+public class StableIdentifierGenerator {
+
+    public static void generateOrthologousStableId(GKInstance inferredInst, GKInstance stableIdentifierInst) {
+
+    }
+}

--- a/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
@@ -32,8 +32,9 @@ public class StableIdentifierGenerator {
         // All Human PhysicalEntitys and Events will have a StableIdentifier instance in the stableIdentifier attribute
         GKInstance stableIdentifierInst = (GKInstance) originalInst.getAttributeValue(stableIdentifier);
         if (stableIdentifierInst == null) {
-            logger.fatal("No stable identifier instance found for " + originalInst);
-            throw new RuntimeException("No stable identifier instance found for " + originalInst);
+            String missingStableIdentifierMsg = "No stable identifier instance found for " + originalInst;
+            logger.fatal(missingStableIdentifierMsg);
+            throw new RuntimeException(missingStableIdentifierMsg);
         }
 
         // For now, Human is hard-coded as the source species, so we replace the stableIdentifier source species based on that assumption
@@ -52,10 +53,11 @@ public class StableIdentifierGenerator {
         // TODO: Performance check
         Collection<GKInstance> existingStableIdentifier = (Collection<GKInstance>) dba.fetchInstanceByAttribute("StableIdentifier", "identifier", "=", targetIdentifier);
 
-        GKInstance orthoStableIdentifierInst = null;
+        GKInstance orthoStableIdentifierInst;
         if (existingStableIdentifier.size() == 0) {
             // Create new StableIdentifier instance
-            orthoStableIdentifierInst = createOrthologousStableIdentifierInstance(stableIdentifierInst, orthoStableIdentifierInst, targetIdentifier);
+            orthoStableIdentifierInst = createOrthologousStableIdentifierInstance(stableIdentifierInst, targetIdentifier);
+            dba.storeInstance(orthoStableIdentifierInst);
         } else {
             orthoStableIdentifierInst = existingStableIdentifier.iterator().next();
         }
@@ -65,14 +67,13 @@ public class StableIdentifierGenerator {
         return inferredInst;
     }
 
-    private GKInstance createOrthologousStableIdentifierInstance(GKInstance stableIdentifierInst, GKInstance orthoStableIdentifierInst, String targetIdentifier) throws Exception {
-        orthoStableIdentifierInst = InstanceUtilities.createNewInferredGKInstance(stableIdentifierInst);
+    private GKInstance createOrthologousStableIdentifierInstance(GKInstance stableIdentifierInst, String targetIdentifier) throws Exception {
+        GKInstance orthoStableIdentifierInst = InstanceUtilities.createNewInferredGKInstance(stableIdentifierInst);
         orthoStableIdentifierInst.addAttributeValue(identifier, targetIdentifier);
         String identifierVersionNumber = "1";
         orthoStableIdentifierInst.addAttributeValue(identifierVersion, identifierVersionNumber);
         String orthoStableIdentifierName = targetIdentifier + "." + identifierVersionNumber;
         orthoStableIdentifierInst.setDisplayName(orthoStableIdentifierName);
-        dba.storeInstance(orthoStableIdentifierInst);
         return orthoStableIdentifierInst;
     }
 }

--- a/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
@@ -32,8 +32,8 @@ public class StableIdentifierGenerator {
         // All Human PhysicalEntitys and Events will have a StableIdentifier instance in the stableIdentifier attribute
         GKInstance stableIdentifierInst = (GKInstance) originalInst.getAttributeValue(stableIdentifier);
         if (stableIdentifierInst == null) {
-            logger.fatal("No stable identifier instance found for " + originalInst + " -- terminating");
-            throw new RuntimeException("Could not find stable identifier instance");
+            logger.fatal("No stable identifier instance found for " + originalInst);
+            throw new RuntimeException("No stable identifier instance found for " + originalInst);
         }
 
         // For now, Human is hard-coded as the source species, so we replace the stableIdentifier source species based on that assumption
@@ -52,16 +52,10 @@ public class StableIdentifierGenerator {
         // TODO: Performance check
         Collection<GKInstance> existingStableIdentifier = (Collection<GKInstance>) dba.fetchInstanceByAttribute("StableIdentifier", "identifier", "=", targetIdentifier);
 
-        GKInstance orthoStableIdentifierInst;
+        GKInstance orthoStableIdentifierInst = null;
         if (existingStableIdentifier.size() == 0) {
             // Create new StableIdentifier instance
-            orthoStableIdentifierInst = InstanceUtilities.createNewInferredGKInstance(stableIdentifierInst);
-            orthoStableIdentifierInst.addAttributeValue(identifier, targetIdentifier);
-            String identifierVersionNumber = "1";
-            orthoStableIdentifierInst.addAttributeValue(identifierVersion, identifierVersionNumber);
-            String orthoStableIdentifierName = targetIdentifier + "." + identifierVersionNumber;
-            orthoStableIdentifierInst.setDisplayName(orthoStableIdentifierName);
-            dba.storeInstance(orthoStableIdentifierInst);
+            orthoStableIdentifierInst = createOrthologousStableIdentifierInstance(stableIdentifierInst, orthoStableIdentifierInst, targetIdentifier);
         } else {
             orthoStableIdentifierInst = existingStableIdentifier.iterator().next();
         }
@@ -69,5 +63,16 @@ public class StableIdentifierGenerator {
         // Populate inferred instance with new StableIdentifier instance
         inferredInst.addAttributeValue(stableIdentifier, orthoStableIdentifierInst);
         return inferredInst;
+    }
+
+    private GKInstance createOrthologousStableIdentifierInstance(GKInstance stableIdentifierInst, GKInstance orthoStableIdentifierInst, String targetIdentifier) throws Exception {
+        orthoStableIdentifierInst = InstanceUtilities.createNewInferredGKInstance(stableIdentifierInst);
+        orthoStableIdentifierInst.addAttributeValue(identifier, targetIdentifier);
+        String identifierVersionNumber = "1";
+        orthoStableIdentifierInst.addAttributeValue(identifierVersion, identifierVersionNumber);
+        String orthoStableIdentifierName = targetIdentifier + "." + identifierVersionNumber;
+        orthoStableIdentifierInst.setDisplayName(orthoStableIdentifierName);
+        dba.storeInstance(orthoStableIdentifierInst);
+        return orthoStableIdentifierInst;
     }
 }

--- a/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
@@ -52,6 +52,7 @@ public class StableIdentifierGenerator {
 
     }
 
+    // speciesAbbreviation is taken from the Species.json file. It is the 3-letter species code that makes up the StableIdentifier. eg: R-'MMU'-123456.
     public static void setSpeciesAbbreviation(String speciesAbbreviationCopy) {
         speciesAbbreviation = speciesAbbreviationCopy;
     }

--- a/orthoinference/src/main/resources/Species.json
+++ b/orthoinference/src/main/resources/Species.json
@@ -23,7 +23,8 @@
 			"Dictyostelium discoideum"
 		],
 		"mart_virtual_schema":"protists_mart",
-		"group":"Eukaryotes"
+		"group":"Eukaryotes",
+		"abbreviation": "DDI"
 	},
 	"cele":{
 		"alt_refdb":{
@@ -48,7 +49,8 @@
 		],
 		"mart_group":"celegans_gene_ensembl",
 		"compara":"core",
-		"group":"Metazoan"
+		"group":"Metazoan",
+		"abbreviation": "CEL"
 	},
 	"scer":{
 		"mart_group":"scerevisiae_gene_ensembl",
@@ -74,7 +76,8 @@
 			"url":"http:\/\/www.yeastgenome.org"
 		},
 		"group":"Fungi\/Plants",
-		"compara":"core"
+		"compara":"core",
+		"abbreviation": "SCE"
 	},
 	"sscr":{
 		"group":"Vertebrate",
@@ -92,7 +95,8 @@
 				"ENSEMBL_Sus_scrofa_PROTEIN"
 			],
 			"access":"http:\/\/www.ensembl.org\/Sus_scrofa\/Transcript\/ProteinSummary?peptide=###ID###"
-		}
+		},
+		"abbreviation": "SSC"
 	},
 	"hsap":{
 		"group":"Human",
@@ -109,7 +113,8 @@
 				"ENSEMBL_Homo_sapiens_PROTEIN"
 			],
 			"access":"http:\/\/www.ensembl.org\/Homo_sapiens\/Transcript\/ProteinSummary?peptide=###ID###"
-		}
+		},
+		"abbreviation": "HSA"
 	},
 	"ggal":{
 		"refdb":{
@@ -127,7 +132,8 @@
 			"Gallus gallus"
 		],
 		"compara":"core",
-		"group":"Vertebrate"
+		"group":"Vertebrate",
+		"abbreviation": "GGA"
 	},
 	"xtro":{
 		"mart_group":"xtropicalis_gene_ensembl",
@@ -145,7 +151,8 @@
 			"ensg_access":"http:\/\/www.ensembl.org\/Xenopus_tropicalis\/geneview?gene=###ID###&db=core"
 		},
 		"group":"Vertebrate",
-		"compara":"core"
+		"compara":"core",
+		"abbreviation": "XTR"
 	},
 	"spom":{
 		"group":"Fungi\/Plants",
@@ -171,7 +178,8 @@
 			"access":"http:\/\/fungi.ensembl.org\/Schizosaccharomyces_pombe\/Transcript\/ProteinSummary?peptide=###ID###",
 			"ensg_access":"http:\/\/fungi.ensembl.org\/Schizosaccharomyces_pombe\/geneview?gene=###ID###&db=core",
 			"url":"http:\/\/fungi.ensembl.org\/Schizosaccharomyces_pombe\/Info\/Index"
-		}
+		},
+		"abbreviation": "SPO"
 	},
 	"btau":{
 		"refdb":{
@@ -189,7 +197,8 @@
 			"Bos taurus"
 		],
 		"compara":"core",
-		"group":"Vertebrate"
+		"group":"Vertebrate",
+		"abbreviation": "BTA"
 	},
 	"mmus":{
 		"refdb":{
@@ -207,7 +216,8 @@
 			"Mus musculus"
 		],
 		"compara":"core",
-		"group":"Vertebrate"
+		"group":"Vertebrate",
+		"abbreviation": "MMU"
 	},
 	"cfam":{
 		"compara":"core",
@@ -225,7 +235,8 @@
 		"name":[
 			"Canis familiaris"
 		],
-		"mart_group":"cfamiliaris_gene_ensembl"
+		"mart_group":"cfamiliaris_gene_ensembl",
+		"abbreviation": "CFA"
 	},
 	"pfal":{
 		"mart_group":"pfalciparum_eg_gene",
@@ -251,7 +262,8 @@
 			"url":"http:\/\/plasmodb.org"
 		},
 		"group":"Eukaryotes",
-		"mart_virtual_schema":"protists_mart"
+		"mart_virtual_schema":"protists_mart",
+		"abbreviation": "PFA"
 	},
 	"dmel":{
 		"compara":"core",
@@ -276,7 +288,8 @@
 		"mart_group":"dmelanogaster_gene_ensembl",
 		"name":[
 			"Drosophila melanogaster"
-		]
+		],
+		"abbreviation": "DME"
 	},
 	"drer":{
 		"mart_group":"drerio_gene_ensembl",
@@ -294,7 +307,8 @@
 			"url":"http:\/\/www.ensembl.org\/Danio_rerio\/Info\/Index\/"
 		},
 		"group":"Vertebrate",
-		"compara":"core"
+		"compara":"core",
+		"abbreviation": "DRE"
 	},
 	"rnor":{
 		"compara":"core",
@@ -312,6 +326,7 @@
 		"mart_group":"rnorvegicus_gene_ensembl",
 		"name":[
 			"Rattus norvegicus"
-		]
+		],
+		"abbreviation": "RNO"
 	}
 }

--- a/orthoinference/src/test/java/org/reactome/orthoinference/StableIdentifierGeneratorTest.java
+++ b/orthoinference/src/test/java/org/reactome/orthoinference/StableIdentifierGeneratorTest.java
@@ -3,7 +3,9 @@ package org.reactome.orthoinference;
 import org.gk.model.GKInstance;
 import org.gk.persistence.MySQLAdaptor;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -14,10 +16,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({StableIdentifierGenerator.class, InstanceUtilities.class})
@@ -65,20 +63,15 @@ public class StableIdentifierGeneratorTest {
         stIdGenerator.generateOrthologousStableId(mockInferredInst, mockOriginalInst);
     }
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
     @Test
     public void generateOrthologousStableIdRuntimeExceptionTest() throws Exception {
-
         Mockito.when(mockOriginalInst.getAttributeValue("stableIdentifier")).thenReturn(null);
 
-        try {
-            stIdGenerator.generateOrthologousStableId(mockInferredInst, mockOriginalInst);
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-            assertTrue(e.getMessage().contains("Could not find stable identifier instance"));
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail();
-        }
-
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("No stable identifier instance found for " + mockOriginalInst);
+        stIdGenerator.generateOrthologousStableId(mockInferredInst, mockOriginalInst);
     }
 }

--- a/orthoinference/src/test/java/org/reactome/orthoinference/StableIdentifierGeneratorTest.java
+++ b/orthoinference/src/test/java/org/reactome/orthoinference/StableIdentifierGeneratorTest.java
@@ -1,0 +1,67 @@
+package org.reactome.orthoinference;
+
+import org.gk.model.GKInstance;
+import org.gk.persistence.MySQLAdaptor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({StableIdentifierGenerator.class, InstanceUtilities.class})
+@PowerMockIgnore({"org.apache.logging.log4j.*", "javax.management.*", "javax.script.*",
+        "javax.xml.*", "com.sun.org.apache.xerces.*", "org.xml.sax.*", "com.sun.xml.*", "org.w3c.dom.*", "org.mockito.*"})
+public class StableIdentifierGeneratorTest {
+
+    private static Object identifier = "R-HSA-123456";
+    private static String fakeAbbreviation = "ABC";
+    @Mock
+    Map<String,Integer> fakeSeenOrthoIds = new HashMap<>();
+
+    @Mock
+    MySQLAdaptor mockAdaptor;
+
+    @Mock
+    GKInstance mockInferredInst;
+
+    @Mock
+    GKInstance mockOriginalInst;
+
+    @Mock
+    GKInstance mockStableIdentifierInst;
+
+    @Mock
+    GKInstance mockOrthoStableIdentifierInst;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void generateOrthologousStableIdTest() throws Exception {
+
+        PowerMockito.mockStatic(InstanceUtilities.class);
+        Mockito.when(mockOriginalInst.getAttributeValue("stableIdentifier")).thenReturn(mockStableIdentifierInst);
+        Mockito.when(mockStableIdentifierInst.getAttributeValue("identifier")).thenReturn(identifier);
+
+        StableIdentifierGenerator.setSpeciesAbbreviation(fakeAbbreviation);
+        StableIdentifierGenerator.setAdaptor(mockAdaptor);
+
+        PowerMockito.when(InstanceUtilities.createNewInferredGKInstance(mockStableIdentifierInst)).thenReturn(mockOrthoStableIdentifierInst);
+
+        StableIdentifierGenerator.generateOrthologousStableId(mockInferredInst, mockOriginalInst);
+
+    }
+}


### PR DESCRIPTION
- This is a  sub-branch of feature/generate_orthoinference_stable_identifiers, and I want to merge it with it's parent

- This code creates a Stable Identifier instance for inferred PhysicalEntitys, ReactionlikeEvents and Pathways during orthoinference

- It adds a single class with 3 entry points in the code; it modifies slightly InstanceUtilities.checkForIdenticalInstances, which now receives the inferred AND original instance (instead of just the inferred instance) when a stableIdentifier needs to be generated. In cases where a stableIdentifier does not need to be generated, 'null' is provided as the second argument