### PR TITLE
Test mode for UpdateDOIs

### DIFF
--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/Main.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/Main.java
@@ -32,6 +32,7 @@ public class Main {
     MySQLAdaptor dbaGkCentral = null;
     long authorIdTR = 0;
     long authorIdGK = 0;
+    boolean testMode = true;
 
     // Properties file should contain information needed to access current Test Reactome and GKCentral databases
     try 
@@ -50,6 +51,7 @@ public class Main {
       authorIdTR = Integer.valueOf(props.getProperty("authorIdTR"));
       authorIdGK = Integer.valueOf(props.getProperty("authorIdGK"));
       int port = Integer.valueOf(props.getProperty("port"));
+      testMode = Boolean.valueOf(props.getProperty("testMode"));
 
       // Set up db connections.
       dbaTestReactome = new MySQLAdaptor(hostTR, databaseTR, userTR, passwordTR, port);
@@ -58,8 +60,8 @@ public class Main {
       e.printStackTrace();
     }
       UpdateDOIs.setAdaptors(dbaTestReactome, dbaGkCentral);
-      UpdateDOIs.findAndUpdateDOIs(authorIdTR, authorIdGK, pathToReport);
-
+      logger.info("Starting UpdateDOIs");
+      UpdateDOIs.findAndUpdateDOIs(authorIdTR, authorIdGK, pathToReport, testMode);
       logger.info( "UpdateDOIs Complete" );
     }
 }

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/Main.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/Main.java
@@ -1,8 +1,5 @@
 package org.reactome.release.updateDOIs;
 
-//import org.apache.logging.log4j.LogManager;
-//import org.apache.logging.log4j.Logger;
-
 import java.io.FileInputStream;
 import java.util.Properties;
 

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/Main.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/Main.java
@@ -51,7 +51,11 @@ public class Main {
       authorIdTR = Integer.valueOf(props.getProperty("authorIdTR"));
       authorIdGK = Integer.valueOf(props.getProperty("authorIdGK"));
       int port = Integer.valueOf(props.getProperty("port"));
-      testMode = Boolean.valueOf(props.getProperty("testMode"));
+      if (props.getProperty("testMode") == null) {
+        testMode = true;
+      } else {
+        testMode = Boolean.valueOf(props.getProperty("testMode"));
+      }
 
       // Set up db connections.
       dbaTestReactome = new MySQLAdaptor(hostTR, databaseTR, userTR, passwordTR, port);
@@ -62,6 +66,10 @@ public class Main {
       UpdateDOIs.setAdaptors(dbaTestReactome, dbaGkCentral);
       logger.info("Starting UpdateDOIs");
       UpdateDOIs.findAndUpdateDOIs(authorIdTR, authorIdGK, pathToReport, testMode);
-      logger.info( "UpdateDOIs Complete" );
+      if (!testMode) {
+        logger.info("UpdateDOIs Complete");
+      } else {
+        logger.info("Finished test run of UpdateDOIs");
+      }
     }
 }

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/Main.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/Main.java
@@ -48,9 +48,7 @@ public class Main {
       authorIdTR = Integer.valueOf(props.getProperty("authorIdTR"));
       authorIdGK = Integer.valueOf(props.getProperty("authorIdGK"));
       int port = Integer.valueOf(props.getProperty("port"));
-      if (props.getProperty("testMode") == null) {
-        testMode = true;
-      } else {
+      if (props.getProperty("testMode") != null) {
         testMode = Boolean.valueOf(props.getProperty("testMode"));
       }
 

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/ReportTests.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/ReportTests.java
@@ -34,7 +34,7 @@ public class ReportTests {
 		// This entails comparing the DB ID, display name and the stable ID version of the provided list (UpdateDOIs.report) with the actual updated instances
 		if (notUpdated.size() > 0)
 		{
-			
+			warningsLog.warn("Some DOIs from UpdateDOIs.report were not updated");
 			ArrayList<String> unresolvedDOIs = new ArrayList<String>();
 			for (String missed : notUpdated) 
 			{

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/ReportTests.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/ReportTests.java
@@ -2,6 +2,8 @@ package org.reactome.release.updateDOIs;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,13 +31,13 @@ public class ReportTests {
 		
 	}
 	
-	public static void expectedUpdatesTests( HashMap<String,HashMap<String,String>> expectedUpdatedDOIs, ArrayList<String> updated, ArrayList<String> notUpdated, int fetchHits ) {
+	public static void expectedUpdatesTests(Map<String,Map<String,String>> expectedUpdatedDOIs, List<String> updated, List<String> notUpdated, int expectedNumberOfUpdatedDOIs ) {
 		// Checking if provided list matched updated instances. Any that don't, it attempts to determine why they might not of been updated.
 		// This entails comparing the DB ID, display name and the stable ID version of the provided list (UpdateDOIs.report) with the actual updated instances
 		if (notUpdated.size() > 0)
 		{
 			warningsLog.warn("Some DOIs from UpdateDOIs.report were not updated");
-			ArrayList<String> unresolvedDOIs = new ArrayList<String>();
+			List<String> unresolvedDOIs = new ArrayList<>();
 			for (String missed : notUpdated) 
 			{
 				String missedDoi = missed.split(":")[0];
@@ -79,7 +81,7 @@ public class ReportTests {
 					warningsLog.warn("[" + unresolvedDOI + "]" + "DOI does not match any DOIs expected to be updated -- Could not match display name or DB ID");
 				}
 			}
-		} else if (expectedUpdatedDOIs.size() != 0 && fetchHits > expectedUpdatedDOIs.size()) {
+		} else if (expectedUpdatedDOIs.size() != 0 && expectedNumberOfUpdatedDOIs > expectedUpdatedDOIs.size()) {
 			warningsLog.warn("The following DOIs were unexpectedly updated: ");
 			for (Object updatedDOI : updated)
 			{

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/ReportTests.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/ReportTests.java
@@ -13,6 +13,7 @@ public class ReportTests {
 	
 	private static final Logger logger = LogManager.getLogger();
 	private static final Logger warningsLog = LogManager.getLogger("warningsLog");
+	private static final String REACTOME_DOI_PREFIX = "10.3180";
 	
 	// Compares the DB IDs and display names of the instances to be updated from Test Reactome and GK Central
 	public static boolean verifyDOIMatches( GKInstance trDOI, GKInstance gkDOI, String newDOI ) {
@@ -42,7 +43,7 @@ public class ReportTests {
 			{
 				String missedDoi = missed.split(":")[0];
 				String missedName = missed.split(":")[1];
-				String missedClean = missedDoi.replace("10.3180/", "");
+				String missedClean = missedDoi.replace(REACTOME_DOI_PREFIX + "/", "");
 				String missedStableId = missedClean.split("\\.")[0];
 				String missedStableIdVersion = missedClean.split("\\.")[1];
 				int resolved = 0;

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/ReportTests.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/ReportTests.java
@@ -13,7 +13,6 @@ public class ReportTests {
 	
 	private static final Logger logger = LogManager.getLogger();
 	private static final Logger warningsLog = LogManager.getLogger("warningsLog");
-	private static final String REACTOME_DOI_PREFIX = "10.3180";
 	
 	// Compares the DB IDs and display names of the instances to be updated from Test Reactome and GK Central
 	public static boolean verifyDOIMatches( GKInstance trDOI, GKInstance gkDOI, String newDOI ) {
@@ -32,7 +31,7 @@ public class ReportTests {
 		
 	}
 	
-	public static void expectedUpdatesTests(Map<String,Map<String,String>> expectedUpdatedDOIs, List<String> updated, List<String> notUpdated, int expectedNumberOfUpdatedDOIs ) {
+	public static void expectedUpdatesTests(Map<String,Map<String,String>> expectedUpdatedDOIs, List<String> updated, List<String> notUpdated, int expectedNumberOfUpdatedDOIs, String REACTOME_DOI_PREFIX) {
 		// Checking if provided list matched updated instances. Any that don't, it attempts to determine why they might not of been updated.
 		// This entails comparing the DB ID, display name and the stable ID version of the provided list (UpdateDOIs.report) with the actual updated instances
 		if (notUpdated.size() > 0)

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
@@ -58,7 +58,7 @@ public class UpdateDOIs {
 		try 
 		{
 			// Get all instances in Test Reactome in the Pathway table that don't have a 'doi' attribute starting with 10.3180, the Reactome DOI standard
-			 doisTR = dbaTestReactome.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180");
+			 doisTR = dbaTestReactome.fetchInstanceByAttribute(ReactomeJavaConstants.Pathway, "doi", "NOT REGEXP", "^10.3180");
 			 logger.info("Found " + doisTR.size() + " Pathway instances that need a DOI");
 			 // GKCentral should require transactional support
 			if (dbaGkCentral.supportsTransactions())
@@ -69,10 +69,10 @@ public class UpdateDOIs {
 					for (GKInstance trDOI : doisTR)
 					{
 						// The dois are constructed from the instances 'stableIdentifier', which should be in the db already
-						String stableIdFromDb = ((GKInstance) trDOI.getAttributeValue("stableIdentifier")).getDisplayName();
-						String nameFromDb = trDOI.getAttributeValue("name").toString();
+						String stableIdFromDb = ((GKInstance) trDOI.getAttributeValue(ReactomeJavaConstants.stableIdentifier)).getDisplayName();
+						String nameFromDb = trDOI.getAttributeValue(ReactomeJavaConstants.name).toString();
 						String updatedDoi = "10.3180/" + stableIdFromDb;
-						String dbId = trDOI.getAttributeValue("DB_ID").toString();
+						String dbId = trDOI.getAttributeValue(ReactomeJavaConstants.DB_ID).toString();
 
 						// Used to verify that report contents are as expected, based on provided list from curators
 						if (expectedUpdatedDOIs.get(updatedDoi) != null && expectedUpdatedDOIs.get(updatedDoi).get("displayName").equals(nameFromDb))
@@ -86,13 +86,13 @@ public class UpdateDOIs {
 							}
 						}
 						// This updates the 'modified' field for Pathways instances, keeping track of when changes happened for each instance
-						trDOI.getAttributeValuesList("modified");
-						trDOI.addAttributeValue("modified", instanceEditTR);
+						trDOI.getAttributeValuesList(ReactomeJavaConstants.modified);
+						trDOI.addAttributeValue(ReactomeJavaConstants.modified, instanceEditTR);
 						trDOI.setAttributeValue("doi", updatedDoi);
 
 						// Grabs instance from GKCentral based on DB_ID taken from Test Reactome and updates it's DOI
 						dbaGkCentral.startTransaction();
-						doisGK = dbaGkCentral.fetchInstanceByAttribute("Pathway", "DB_ID", "=", dbId);
+						doisGK = dbaGkCentral.fetchInstanceByAttribute(ReactomeJavaConstants.Pathway, ReactomeJavaConstants.DB_ID, "=", dbId);
 						if (!doisGK.isEmpty())
 						{
 							for (GKInstance gkDOI : doisGK)
@@ -100,11 +100,11 @@ public class UpdateDOIs {
 								boolean verified = ReportTests.verifyDOIMatches(trDOI, gkDOI, updatedDoi);
 								if (verified) 
 								{
-									gkDOI.getAttributeValuesList("modified");
-									gkDOI.addAttributeValue("modified", instanceEditGK);
+									gkDOI.getAttributeValuesList(ReactomeJavaConstants.modified);
+									gkDOI.addAttributeValue(ReactomeJavaConstants.modified, instanceEditGK);
 									gkDOI.setAttributeValue("doi", updatedDoi);
 									if (!testMode) {
-										dbaGkCentral.updateInstanceAttribute(gkDOI, "modified");
+										dbaGkCentral.updateInstanceAttribute(gkDOI, ReactomeJavaConstants.modified);
 										dbaGkCentral.updateInstanceAttribute(gkDOI, "doi");
 									}
 								} else {
@@ -120,7 +120,7 @@ public class UpdateDOIs {
 							logger.error("Could not find attribute in gk_central");
 						}
 						if (!testMode) {
-							dbaTestReactome.updateInstanceAttribute(trDOI, "modified");
+							dbaTestReactome.updateInstanceAttribute(trDOI, ReactomeJavaConstants.modified);
 							dbaTestReactome.updateInstanceAttribute(trDOI, "doi");
 						}
 					}

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
@@ -1,9 +1,7 @@
 package org.reactome.release.updateDOIs;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
+import java.util.*;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,14 +48,13 @@ public class UpdateDOIs {
 			instanceEditGK = UpdateDOIs.createInstanceEdit(UpdateDOIs.dbaGkCentral, authorIdGK, creatorFile);
 		}
 		// Gets the updated report file if it was provided for this release
-		HashMap<String, HashMap<String,String>> expectedUpdatedDOIs = UpdateDOIs.getExpectedUpdatedDOIs(pathToReport);
+		Map<String, Map<String,String>> expectedUpdatedDOIs = UpdateDOIs.getExpectedUpdatedDOIs(pathToReport);
 		if (expectedUpdatedDOIs.size() == 0) {
 			logger.warn("No DOIs listed in UpdateDOIs.report. Please add expected DOI and displayName to UpdateDOIs.report.");
 			return;
 		}
-		ArrayList<String> updated = new ArrayList<String>();
-		ArrayList<String> notUpdated = new ArrayList<String>();
-		int fetchHits = 0;
+		List<String> updated = new ArrayList<>();
+		List<String> notUpdated = new ArrayList<>();
 		try 
 		{
 			// Get all instances in Test Reactome in the Pathway table that don't have a 'doi' attribute starting with 10.3180, the Reactome DOI standard
@@ -78,7 +75,6 @@ public class UpdateDOIs {
 						String dbId = trDOI.getAttributeValue("DB_ID").toString();
 
 						// Used to verify that report contents are as expected, based on provided list from curators
-						fetchHits++;
 						if (expectedUpdatedDOIs.get(updatedDoi) != null && expectedUpdatedDOIs.get(updatedDoi).get("displayName").equals(nameFromDb))
 						{
 							updated.add(updatedDoi);
@@ -128,7 +124,7 @@ public class UpdateDOIs {
 							dbaTestReactome.updateInstanceAttribute(trDOI, "doi");
 						}
 					}
-					ReportTests.expectedUpdatesTests(expectedUpdatedDOIs, updated, notUpdated, fetchHits );
+					ReportTests.expectedUpdatesTests(expectedUpdatedDOIs, updated, notUpdated, doisTR.size());
 				} else {
 					logger.info("No DOIs to update");
 				}
@@ -153,9 +149,9 @@ public class UpdateDOIs {
 	}
 
 	// Parses input report and places each line's contents in HashMap
-	public static HashMap<String, HashMap<String,String>> getExpectedUpdatedDOIs(String pathToReport) {
+	public static Map<String, Map<String,String>> getExpectedUpdatedDOIs(String pathToReport) {
 
-		HashMap<String, HashMap<String, String>> expectedUpdatedDOIs = new HashMap<String, HashMap<String,String>>();
+		Map<String, Map<String, String>> expectedUpdatedDOIs = new HashMap<>();
 		try 
 		{
 			FileReader fr = new FileReader(pathToReport);
@@ -164,7 +160,7 @@ public class UpdateDOIs {
 			String sCurrentLine;
 			while ((sCurrentLine = br.readLine()) != null) 
 			{
-				HashMap<String, String> doiAttributes = new HashMap<String,String>();
+				Map<String, String> doiAttributes = new HashMap<>();
 				String[] commaSplit = sCurrentLine.split(",", 2);
 				String reactomeDoi = commaSplit[0];
 				String displayName = commaSplit[1];
@@ -239,7 +235,7 @@ public class UpdateDOIs {
 			} else {
 				// This 'else' block wasn't here when first copied from ReferenceCreator. Added
 				// to reduce future potential headaches. (JC)
-				System.out.println("needStore set to false");
+				logger.info("needStore set to false");
 			}
 			return newIE;
 		} else {

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
@@ -125,7 +125,7 @@ public class UpdateDOIs {
 							dbaTestReactome.updateInstanceAttribute(trDOI, "doi");
 						}
 					}
-					ReportTests.expectedUpdatesTests(expectedUpdatedDOIs, updated, notUpdated, doisTR.size());
+					ReportTests.expectedUpdatesTests(expectedUpdatedDOIs, updated, notUpdated, doisTR.size(), REACTOME_DOI_PREFIX);
 				} else {
 					logger.info("No DOIs to update");
 				}

--- a/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
+++ b/update-dois/src/main/java/org/reactome/release/updateDOIs/UpdateDOIs.java
@@ -19,6 +19,7 @@ public class UpdateDOIs {
 
 	private static final Logger logger = LogManager.getLogger();
 	private static final Logger warningsLog = LogManager.getLogger("warningsLog");
+	private static final String REACTOME_DOI_PREFIX = "10.3180";
 
 	private static MySQLAdaptor dbaTestReactome;
 	private static MySQLAdaptor dbaGkCentral;
@@ -58,7 +59,7 @@ public class UpdateDOIs {
 		try 
 		{
 			// Get all instances in Test Reactome in the Pathway table that don't have a 'doi' attribute starting with 10.3180, the Reactome DOI standard
-			 doisTR = dbaTestReactome.fetchInstanceByAttribute(ReactomeJavaConstants.Pathway, "doi", "NOT REGEXP", "^10.3180");
+			 doisTR = dbaTestReactome.fetchInstanceByAttribute(ReactomeJavaConstants.Pathway, "doi", "NOT REGEXP", "^" + REACTOME_DOI_PREFIX);
 			 logger.info("Found " + doisTR.size() + " Pathway instances that need a DOI");
 			 // GKCentral should require transactional support
 			if (dbaGkCentral.supportsTransactions())
@@ -71,7 +72,7 @@ public class UpdateDOIs {
 						// The dois are constructed from the instances 'stableIdentifier', which should be in the db already
 						String stableIdFromDb = ((GKInstance) trDOI.getAttributeValue(ReactomeJavaConstants.stableIdentifier)).getDisplayName();
 						String nameFromDb = trDOI.getAttributeValue(ReactomeJavaConstants.name).toString();
-						String updatedDoi = "10.3180/" + stableIdFromDb;
+						String updatedDoi = REACTOME_DOI_PREFIX + "/" + stableIdFromDb;
 						String dbId = trDOI.getAttributeValue(ReactomeJavaConstants.DB_ID).toString();
 
 						// Used to verify that report contents are as expected, based on provided list from curators
@@ -166,7 +167,7 @@ public class UpdateDOIs {
 				String displayName = commaSplit[1];
 				int lastPeriodIndex = commaSplit[0].lastIndexOf(".");
 				String[] versionSplit = {reactomeDoi.substring(0, lastPeriodIndex), reactomeDoi.substring(lastPeriodIndex+1)};
-				String stableId = versionSplit[0].replace("10.3180/", "");
+				String stableId = versionSplit[0].replace(REACTOME_DOI_PREFIX + "/", "");
 				String stableIdVersion = versionSplit[1];
 				doiAttributes.put("displayName", displayName);
 				doiAttributes.put("stableId", stableId);

--- a/update-dois/src/main/resources/config.properties
+++ b/update-dois/src/main/resources/config.properties
@@ -1,0 +1,12 @@
+userTR=testReactomeMySQLUsername
+userGK=centralMySQLUsername
+passwordTR=testReactomePassword
+passwordGK=centralUsername
+hostTR=testReactomeHost
+hostGK=centralHost
+databaseTR=release_current
+databaseGK=central
+authorIdTR=personId
+authorIdGK=personId
+port=3306
+testMode=true

--- a/update-dois/src/test/java/org/reactome/release/updateDOIs/TestUpdateDOIs.java
+++ b/update-dois/src/test/java/org/reactome/release/updateDOIs/TestUpdateDOIs.java
@@ -49,7 +49,7 @@ public class TestUpdateDOIs {
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180")).thenReturn(testResults);
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "DB_ID", "=", "67890")).thenReturn(testResults);
 		
-		check.findAndUpdateDOIs(12345L, 67890L, "reportPath");
+		check.findAndUpdateDOIs(12345L, 67890L, "reportPath", true);
     }
 	
 	@Test
@@ -61,7 +61,7 @@ public class TestUpdateDOIs {
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180")).thenReturn(new ArrayList<GKInstance>());
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "DB_ID", "=", "67890")).thenReturn(new ArrayList<GKInstance>());
 		
-		check.findAndUpdateDOIs(12345L, 67890L, "reportPath");
+		check.findAndUpdateDOIs(12345L, 67890L, "reportPath", true);
 	}
 	
 	@Test
@@ -80,6 +80,6 @@ public class TestUpdateDOIs {
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "doi", "NOT REGEXP", "^10.3180")).thenReturn(testResults);
 		Mockito.when(mockAdaptor.fetchInstanceByAttribute("Pathway", "DB_ID", "=", "67890")).thenReturn(new ArrayList<GKInstance>());
 		
-		check.findAndUpdateDOIs(12345L, 67890L, "reportPath");
+		check.findAndUpdateDOIs(12345L, 67890L, "reportPath", true);
 	}
 }


### PR DESCRIPTION
Small PR that allows the user to run a test mode of UpdateDOIs. This will output all DOIs that would be updated during this run. This list can be confirmed by the curators and can all be used to populate the UpdateDOIs.report file that a real run will use. Also added some additional logging statements and a sample config.properties file