### PR TITLE
EWASInferrer changes to accomodate varying Orthopair file formats

### DIFF
--- a/orthoinference/src/main/java/org/reactome/orthoinference/EWASInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EWASInferrer.java
@@ -41,7 +41,12 @@ public class EWASInferrer {
 		if (homologueMappings.get(referenceEntityId) != null)
 		{
 			// Iterate through the array of homologue mappings, attempting to infer EWAS instances for each.
-			for (String homologueId : homologueMappings.get(referenceEntityId)) {
+			for (String homologue : homologueMappings.get(referenceEntityId)) {
+
+				// Handles homologues formatted as either DB:ID or just ID
+				String homologueSource = homologue.contains(":") ? homologue.split(":")[0] : "";
+				String homologueId = homologue.contains(":") ? homologue.split(":")[1] : homologue;
+
 				if (checkValidSpeciesProtein(homologueId)) {
 					GKInstance infReferenceGeneProductInst = null;
 					if (referenceGeneProductIdenticals.get(homologueId) == null) {
@@ -49,7 +54,7 @@ public class EWASInferrer {
 						infReferenceGeneProductInst.addAttributeValue(identifier, homologueId);
 						// Reference DB can differ between homologue mappings, but can be differentiated by the 'homologueSource' found in each mapping.
 						// With PANTHER data, the Protein IDs are exclusively UniProt
-						GKInstance referenceDatabaseInst = uniprotDbInst;
+						GKInstance referenceDatabaseInst = homologueSource.equals("ENSP") ? enspDbInst : uniprotDbInst;
 						infReferenceGeneProductInst.addAttributeValue(referenceDatabase, referenceDatabaseInst);
 
 						// Creates ReferenceDNASequence instance from ReferenceEntity
@@ -57,7 +62,8 @@ public class EWASInferrer {
 						infReferenceGeneProductInst.addAttributeValue(referenceGene, inferredReferenceDNAInstances);
 
 						infReferenceGeneProductInst.addAttributeValue(species, speciesInst);
-						infReferenceGeneProductInst.setAttributeValue(_displayName, "UniProt:" + homologueId);
+						String referenceGeneProductSource = homologueSource.equals("ENSP") ? "ENSEMBL:" : "UniProt:";
+						infReferenceGeneProductInst.setAttributeValue(_displayName, referenceGeneProductSource + homologueId);
 						infReferenceGeneProductInst = InstanceUtilities.checkForIdenticalInstances(infReferenceGeneProductInst);
 						referenceGeneProductIdenticals.put(homologueId, infReferenceGeneProductInst);
 					} else {
@@ -261,9 +267,11 @@ public class EWASInferrer {
 		{
 			String[] tabSplit = currentLine.split("\t");
 			String ensgKey = tabSplit[0];
-			String[] proteinIds = tabSplit[1].split(" ");
-			for (String proteinId : proteinIds)
+			String[] proteins = tabSplit[1].split(" ");
+			for (String protein : proteins)
 			{
+				String proteinId = protein.contains(":") ? protein.split(":")[1] : protein;
+
 				if (ensgMappings.get(proteinId) == null)
 				{
 					List<String> singleArray = new ArrayList<>();


### PR DESCRIPTION
This is in response to a request from @preecej to allow the original and new orthopair files to both be used in orthoinference. 