### PR TITLE
Orthopair fix for LDOs that are also Os

### DIFF
--- a/orthopairs/src/main/java/org/reactome/release/orthopairs/Main.java
+++ b/orthopairs/src/main/java/org/reactome/release/orthopairs/Main.java
@@ -3,6 +3,7 @@ package org.reactome.release.orthopairs;
 import java.io.*;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
@@ -77,6 +78,12 @@ public class Main
         List<String> pantherFiles = new ArrayList<String>(Arrays.asList(pantherQfOFilename, pantherHCOPFilename));
         for (String pantherFilename : pantherFiles) {
             downloadAndExtractTarFile(pantherFilename, pantherFilepath);
+        }
+        // QfO_Genome_Orthologs.tar.gz extracts a file named 'QfO_Genome_Orthologs_pairwise', which is unexpected.
+        // This just prunes the '_pairwise' string from the filename.
+        Path extractedPantherQfOFilePath = Paths.get(pantherQfOFilename.replace(".tar.gz", ""));
+        if (!Files.exists(extractedPantherQfOFilePath)) {
+            Files.move(Paths.get(extractedPantherQfOFilePath + "_pairwise"), extractedPantherQfOFilePath);
         }
 
         // Download ID files from various model organism databases (Mouse Genome Informatics, Rat Genome Database, Xenbase (frog), ZFIN (Zebrafish))

--- a/orthopairs/src/main/java/org/reactome/release/orthopairs/OrthologyFileParser.java
+++ b/orthopairs/src/main/java/org/reactome/release/orthopairs/OrthologyFileParser.java
@@ -73,23 +73,8 @@ public class OrthologyFileParser {
     }
 
     private static Map<String, Map<String, Set<String>>> MapId(String targetSpecies, String keyEntity, String valueEntity, Map<String,Map<String,Set<String>>> entityMap, String orthologType) {
-        // The 'null' conditionals are for the first time that level of the map is added. For example, if 'MOUSE' doesn't have an existing structure in the map,
-        // the first condition will handle this.
-        //Set<String>  firstTargetEntityIdAdded = new HashSet<>(Arrays.asList(valueEntity));
-        //Map<String,Set<String>> firstSourceEntityMap = new HashMap<>();
-        //firstSourceEntityMap.put(keyEntity, firstTargetEntityIdAdded);
+        
         entityMap.computeIfAbsent(targetSpecies, k -> new HashMap<>());
-        /*
-        else {
-            if (entityMap.get(targetSpecies).get(keyEntity) == null) {
-                Set<String> firstTargetEntityIdAdded = new HashSet<>(Arrays.asList(valueEntity));
-                entityMap.get(targetSpecies).put(keyEntity, firstTargetEntityIdAdded);
-            } else {
-                entityMap.get(targetSpecies).get(keyEntity).add(valueEntity);
-            }
-        }
-        */
-
         // Lines with an orthologType equal to 'LDO' mean that we only want that value in the Set since its the Least Diverged Ortholog, meaning we have a
         // high degree of confidence in its homology. We remove all other values from the Set unless an 'LDO' value already exists. In this rare case,
         // we will keep multiple LDOs.

--- a/orthopairs/src/main/java/org/reactome/release/orthopairs/OrthologyFileParser.java
+++ b/orthopairs/src/main/java/org/reactome/release/orthopairs/OrthologyFileParser.java
@@ -43,7 +43,6 @@ public class OrthologyFileParser {
                     // For Ortholog type, we only want to look at the Least Divered Ortholog(LDO) and Ortholog(O) lines.
                     if (line.startsWith(sourceSpeciesPantherName)) {
                         String[] tabSplit = line.split("\t");
-
                         String sourceInfo = tabSplit[0];
                         String[] sourceSplit = sourceInfo.split("\\|");
                         String sourceGene = sourceSplit[1];
@@ -74,15 +73,14 @@ public class OrthologyFileParser {
     }
 
     private static Map<String, Map<String, Set<String>>> MapId(String targetSpecies, String keyEntity, String valueEntity, Map<String,Map<String,Set<String>>> entityMap, String orthologType) {
-
         // The 'null' conditionals are for the first time that level of the map is added. For example, if 'MOUSE' doesn't have an existing structure in the map,
         // the first condition will handle this.
-        if (entityMap.get(targetSpecies) == null) {
-            Set<String>  firstTargetEntityIdAdded = new HashSet<>(Arrays.asList(valueEntity));
-            Map<String,Set<String>> firstSourceEntityMap = new HashMap<>();
-            firstSourceEntityMap.put(keyEntity, firstTargetEntityIdAdded);
-            entityMap.put(targetSpecies, firstSourceEntityMap);
-        } else {
+        //Set<String>  firstTargetEntityIdAdded = new HashSet<>(Arrays.asList(valueEntity));
+        //Map<String,Set<String>> firstSourceEntityMap = new HashMap<>();
+        //firstSourceEntityMap.put(keyEntity, firstTargetEntityIdAdded);
+        entityMap.computeIfAbsent(targetSpecies, k -> new HashMap<>());
+        /*
+        else {
             if (entityMap.get(targetSpecies).get(keyEntity) == null) {
                 Set<String> firstTargetEntityIdAdded = new HashSet<>(Arrays.asList(valueEntity));
                 entityMap.get(targetSpecies).put(keyEntity, firstTargetEntityIdAdded);
@@ -90,20 +88,24 @@ public class OrthologyFileParser {
                 entityMap.get(targetSpecies).get(keyEntity).add(valueEntity);
             }
         }
+        */
 
         // Lines with an orthologType equal to 'LDO' mean that we only want that value in the Set since its the Least Diverged Ortholog, meaning we have a
         // high degree of confidence in its homology. We remove all other values from the Set unless an 'LDO' value already exists. In this rare case,
         // we will keep multiple LDOs.
-        Set<String> targetEntitys = entityMap.get(targetSpecies).get(keyEntity);
+        Set<String> targetEntitys = Optional.ofNullable(entityMap.get(targetSpecies).get(keyEntity)).orElse(new HashSet<>());
+
         if (orthologType.equals("LDO")) {
             if (!targetEntitys.contains("LDO")) {
                 targetEntitys.clear();
                 targetEntitys.add(valueEntity);
                 targetEntitys.add("LDO");
-                entityMap.get(targetSpecies).put(keyEntity, targetEntitys);
+            } else {
+                targetEntitys.add(valueEntity);
             }
-        } else if (orthologType.equals("O") && targetEntitys.contains("LDO")) {
-            targetEntitys.remove(valueEntity);
+            entityMap.get(targetSpecies).put(keyEntity, targetEntitys);
+        } else if (orthologType.equals("O") && !targetEntitys.contains("LDO")) {
+            targetEntitys.add(valueEntity);
             entityMap.get(targetSpecies).put(keyEntity, targetEntitys);
         }
         return entityMap;


### PR DESCRIPTION
Very small PR that should have been posted after last release. Minor change to Orthopairs code to account for protein's that are an LDO (least diverged ortholog) for one reference protein but are just an O for a different protein. Due to the structure of the data, there was some overwrite happening. 