### PR TITLE
Fix to prevent modified attribute being overwritten in UpdateStableIds

### DIFF
--- a/updateStableIds/src/main/java/org/reactome/release/updateStableIds/StableIdentifierUpdater.java
+++ b/updateStableIds/src/main/java/org/reactome/release/updateStableIds/StableIdentifierUpdater.java
@@ -98,7 +98,6 @@ public class StableIdentifierUpdater {
 				logger.warn(sliceInstance + " -- Instance not found in gkCentral");
 			}
 		}
-
 		// TODO: Update test_slice after gkCentral has been successfully updated
 		if (dbaSlice.supportsTransactions()) {
 			dbaSlice.commit();
@@ -120,6 +119,7 @@ public class StableIdentifierUpdater {
 
 		stableIdentifierInst.addAttributeValue(identifierVersion, String.valueOf(newIdentifierVersion));
 		stableIdentifierInst.setDisplayName(id + "." + newIdentifierVersion);
+		Collection<GKInstance> modifiedInstances = (Collection<GKInstance>) stableIdentifierInst.getAttributeValuesList(modified);
 		stableIdentifierInst.addAttributeValue(modified, instanceEdit);
 		dba.updateInstanceAttribute(stableIdentifierInst, identifierVersion);
 		dba.updateInstanceAttribute(stableIdentifierInst, _displayName);


### PR DESCRIPTION
The 'modified' attribute of StableIdentifier instances was getting overwritten since the collection was not loaded. This just calls `getAttributeValuesList("modified")` to load the attributes.