### PR TITLE
Feature/orthoinference stable id fix

### DIFF
--- a/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
@@ -40,14 +40,14 @@ public class StableIdentifierGenerator {
         // For now, Human is hard-coded as the source species, so we replace the stableIdentifier source species based on that assumption
         String sourceIdentifier = (String) stableIdentifierInst.getAttributeValue(identifier);
         String targetIdentifier = sourceIdentifier.replace("HSA", speciesAbbreviation);
-
         // Paralogs will have the same base stable identifier, but we want to denote when that happens.
         // We pull the value from `seenOrthoIds`, increment it and then add it to the stable identifier name (eg: R-MMU-123456-2)
         int paralogCount = Optional.ofNullable(seenOrthoIds.get(targetIdentifier)).orElse(0) + 1;
+        String targetIdentifierUnmodified = targetIdentifier;
         if (paralogCount > 1) {
             targetIdentifier += "-" + paralogCount;
         }
-        seenOrthoIds.put(targetIdentifier, paralogCount);
+        seenOrthoIds.put(targetIdentifierUnmodified, paralogCount);
 
         // Check that the stable identifier instance does not already exist in DB
         // TODO: Performance check

--- a/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/StableIdentifierGenerator.java
@@ -43,11 +43,11 @@ public class StableIdentifierGenerator {
         // Paralogs will have the same base stable identifier, but we want to denote when that happens.
         // We pull the value from `seenOrthoIds`, increment it and then add it to the stable identifier name (eg: R-MMU-123456-2)
         int paralogCount = Optional.ofNullable(seenOrthoIds.get(targetIdentifier)).orElse(0) + 1;
-        String targetIdentifierUnmodified = targetIdentifier;
+        seenOrthoIds.put(targetIdentifier, paralogCount);
         if (paralogCount > 1) {
             targetIdentifier += "-" + paralogCount;
         }
-        seenOrthoIds.put(targetIdentifierUnmodified, paralogCount);
+
 
         // Check that the stable identifier instance does not already exist in DB
         // TODO: Performance check


### PR DESCRIPTION
UPDATE: I changed the base branch of this to merge into OrthoDiagrams. OrthoDiagrams is pending due to a need for proper unit testing. I'd like to merge this branch into it before I merge the orthodiagrams one into develop. This PR should be much, much smaller now

This fixes the fact that stableIdentifier versions were not being incremented properly. This is because stable identifiers were being stored with the newly incremented value as the key, instead of using the original stable identifier. 

Example: R-MMU-12345 is used 4 times in 4 different (but likely related) PhysicalEntitys. The old (incorrect) way would produce [R-MMU-12345, R-12345-2, R-MMU-12345-2, R-MMU-12345-2]. The correct way would be for it to be 12345, 12345-2, 12345-3, 12345-4. This PR fixes that 