### PR TITLE
Orthoinference report files now append instead of overwrites them

### DIFF
--- a/orthoinference/runOrthoinference.sh
+++ b/orthoinference/runOrthoinference.sh
@@ -13,8 +13,8 @@ mvn clean compile assembly:single
 allSpecies=(mmus rnor cfam btau sscr drer xtro ggal dmel cele ddis spom scer pfal)
 for species in "${allSpecies[@]}"
 do
-	echo "java -jar target/orthoinference-0.0.1-SNAPSHOT-jar-with-dependencies.jar $species > orthoinference_$species.out";
-	java -jar target/orthoinference-0.0.1-SNAPSHOT-jar-with-dependencies.jar $species > orthoinference_$species.out;
+	echo "java -jar target/orthoinference-0.0.2-SNAPSHOT-jar-with-dependencies.jar $species > orthoinference_$species.out";
+	java -jar target/orthoinference-0.0.2-SNAPSHOT-jar-with-dependencies.jar $species > orthoinference_$species.out;
 done
 echo "Orthoinference complete"
 

--- a/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -74,7 +74,6 @@ public class EventsInferrer
 		}
 		setDbAdaptors(dbAdaptor);
 
-
 		releaseVersion = props.getProperty("releaseNumber");
 		String pathToOrthopairs = props.getProperty("pathToOrthopairs");
 		String pathToSpeciesConfig = props.getProperty("pathToSpeciesConfig");
@@ -240,7 +239,9 @@ public class EventsInferrer
 		// Create file if it doesn't exist
 		String reportFilename = "report_ortho_inference_test_reactome_" + releaseVersion + ".txt";
 		logger.info("Updating " + reportFilename);
-		createNewFile(reportFilename);
+		if (!Files.exists(Paths.get(reportFilename))) {
+			createNewFile(reportFilename);
+		}
 		String results = "hsap to " + species + ":\t" + inferredCount + " out of " + eligibleCount + " eligible reactions (" + String.format("%.2f", percentInferred) + "%)\n";
 		Files.write(Paths.get(reportFilename), results.getBytes(), StandardOpenOption.APPEND);
 	}


### PR DESCRIPTION
May want to incorporate into the bash file something that removes the report file so that we aren't appending over multiple releases, but implementation is something we can discuss