### PR TITLE
Feature/orthoinference 71 updates

### DIFF
--- a/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -113,6 +113,7 @@ public class EventsInferrer
 			Map<String,String[]> homologueMappings = readHomologueMappingFile(species, "hsap", pathToOrthopairs);
 			ProteinCountUtility.setHomologueMappingFile(homologueMappings);
 			EWASInferrer.setHomologueMappingFile(homologueMappings);
+			SkipInstanceChecker.setHomologueMappingFile(homologueMappings);
 		} catch (FileNotFoundException e) {
 			logger.fatal("Unable to locate " + speciesName +" mapping file: hsap_" + species + "_mapping.txt. Orthology prediction not possible.");
 			return;
@@ -168,11 +169,9 @@ public class EventsInferrer
 			List<GKInstance> previouslyInferredInstances = new ArrayList<GKInstance>();
 			previouslyInferredInstances = checkIfPreviouslyInferred(reactionInst, orthologousEvent, previouslyInferredInstances);
 			previouslyInferredInstances = checkIfPreviouslyInferred(reactionInst, inferredFrom, previouslyInferredInstances);
-			if (previouslyInferredInstances.size() > 0)
-			{
+			if (previouslyInferredInstances.size() > 0) {
 				GKInstance prevInfInst = previouslyInferredInstances.get(0);
-				if (prevInfInst.getAttributeValue(disease) == null)
-				{
+				if (prevInfInst.getAttributeValue(disease) == null) {
 					logger.info("Inferred RlE already exists, skipping inference");
 					manualEventToNonHumanSource.put(reactionInst, prevInfInst);
 					manualHumanEvents.add(reactionInst);

--- a/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -53,6 +53,8 @@ public class EventsInferrer
 	private static List<GKInstance> eventsAlreadyInferred = new ArrayList<>();
 	private static StableIdentifierGenerator stableIdentifierGenerator;
 	private static OrthologousPathwayDiagramGenerator orthologousPathwayDiagramGenerator;
+	private static final String summationText = "This event has been computationally inferred from an event that has been demonstrated in another species.<p>The inference is based on the homology mapping from PANTHER. Briefly, reactions for which all involved PhysicalEntities (in input, output and catalyst) have a mapped orthologue/paralogue (for complexes at least 75% of components must have a mapping) are inferred to the other species. High level events are also inferred for these events to allow for easier navigation.<p><a href='/electronic_inference_compara.html' target = 'NEW'>More details and caveats of the event inference in Reactome.</a> For details on PANTHER see also: <a href='http://www.pantherdb.org/about.jsp' target='NEW'>http://www.pantherdb.org/about.jsp</a>";
+
 
 	@SuppressWarnings("unchecked")
 	public static void inferEvents(Properties props, String species) throws Exception
@@ -171,12 +173,14 @@ public class EventsInferrer
 			previouslyInferredInstances.addAll(checkIfPreviouslyInferred(reactionInst, inferredFrom, previouslyInferredInstances));
 			if (previouslyInferredInstances.size() > 0) {
 				GKInstance prevInfInst = previouslyInferredInstances.get(0);
-				if (prevInfInst.getAttributeValue(disease) == null) {
+				GKInstance prevInfSummationInst = (GKInstance) prevInfInst.getAttributeValue(summation);
+				String prevInfSummationText = prevInfSummationInst.getAttributeValue(text).toString();
+				if (prevInfInst.getAttributeValue(disease) == null &&  prevInfSummationText.equals(summationText)) {
 					logger.info("Inferred RlE already exists, skipping inference");
 					eventsAlreadyInferredMap.put(reactionInst, prevInfInst);
 					eventsAlreadyInferred.add(reactionInst);
 				} else {
-					logger.info("Disease reaction, skipping inference");
+					logger.info("Either a disease or manually inferred reaction, skipping inference");
 				}
 				continue;
 			}
@@ -304,7 +308,6 @@ public class EventsInferrer
 		GKInstance summationInst = new GKInstance(dbAdaptor.getSchema().getClassByName(Summation));
 		summationInst.setDbAdaptor(dbAdaptor);
 		summationInst.addAttributeValue(created, instanceEditInst);
-		String summationText = "This event has been computationally inferred from an event that has been demonstrated in another species.<p>The inference is based on the homology mapping from PANTHER. Briefly, reactions for which all involved PhysicalEntities (in input, output and catalyst) have a mapped orthologue/paralogue (for complexes at least 75% of components must have a mapping) are inferred to the other species. High level events are also inferred for these events to allow for easier navigation.<p><a href='/electronic_inference_compara.html' target = 'NEW'>More details and caveats of the event inference in Reactome.</a> For details on PANTHER see also: <a href='http://www.pantherdb.org/about.jsp' target='NEW'>http://www.pantherdb.org/about.jsp</a>";
 		summationInst.addAttributeValue(text, summationText);
 		summationInst.addAttributeValue(_displayName, summationText);
 		summationInst = InstanceUtilities.checkForIdenticalInstances(summationInst, null);

--- a/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/EventsInferrer.java
@@ -105,7 +105,7 @@ public class EventsInferrer
 		String inferredFilename = "inferred_" + species + "_75.txt";
 		createNewFile(eligibleFilename);
 		createNewFile(inferredFilename);
-		ReactionInferrer.setEligibleFilename(eligibleFilename);
+		SkipInstanceChecker.setEligibleFilename(eligibleFilename);
 		ReactionInferrer.setInferredFilename(inferredFilename);
 
 		stableIdentifierGenerator = new StableIdentifierGenerator(dbAdaptor, (String) speciesObject.get("abbreviation"));
@@ -239,7 +239,7 @@ public class EventsInferrer
 
 	private static void outputReport(String species) throws IOException
 	{
-		int eligibleCount = ReactionInferrer.getEligibleCount();
+		int eligibleCount = SkipInstanceChecker.getEligibleCount();
 		int inferredCount = ReactionInferrer.getInferredCount();
 		float percentInferred = (float) 100*inferredCount/eligibleCount;
 		// Create file if it doesn't exist
@@ -247,8 +247,10 @@ public class EventsInferrer
 		logger.info("Updating " + reportFilename);
 		if (!Files.exists(Paths.get(reportFilename))) {
 			createNewFile(reportFilename);
+			String reportHeader = "## Number of inferred reactions by species for Reactome Release " + releaseVersion;
+			Files.write(Paths.get(reportFilename), reportHeader.getBytes(), StandardOpenOption.APPEND);
 		}
-		String results = "hsap to " + species + ":\t" + inferredCount + " out of " + eligibleCount + " eligible reactions (" + String.format("%.2f", percentInferred) + "%)\n";
+		String results = "hsap to " + species + ":\tInferred " + inferredCount + " out of " + eligibleCount + " eligible reactions (" + String.format("%.2f", percentInferred) + "%)\n";
 		Files.write(Paths.get(reportFilename), results.getBytes(), StandardOpenOption.APPEND);
 	}
 	

--- a/orthoinference/src/main/java/org/reactome/orthoinference/OrthologousEntityGenerator.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/OrthologousEntityGenerator.java
@@ -174,7 +174,7 @@ public class OrthologousEntityGenerator {
 	}
 	// Infers Complex or Polymer instances. These instances are generally comprised of more than 1 PhysicalEntity, and calls 'createOrthoEntity' for each one. Complex/Polymer instances
 	// are also subject to the 'countDistinctProteins' function. The result from this needs to have at least 75% of total proteins to be inferrable for inference to continue. 
-	private static GKInstance createInfComplexPolymer(GKInstance complexInst, boolean override) throws InvalidAttributeException, InvalidAttributeValueException, Exception
+	private static GKInstance createInfComplexPolymer(GKInstance complexInst, boolean override) throws Exception
 	{
 		if (complexPolymerIdenticals.get(complexInst) == null)
 		{

--- a/orthoinference/src/main/java/org/reactome/orthoinference/PathwaysInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/PathwaysInferrer.java
@@ -47,8 +47,6 @@ public class PathwaysInferrer {
 		addInferredEventsToInferredPathways();
 		logger.info("Finished populating inferred Pathways with inferred Events");
 
-		//TODO: LOG starting HERE
-
 		// Connect preceding events to RlEs, if they have any in the source species.
 		logger.info("Adding preceding events to inferred Events");
 		inferPrecedingEvents();
@@ -168,40 +166,31 @@ public class PathwaysInferrer {
 	private static void inferPrecedingEvents() throws Exception
 	{
 		Set<GKInstance> seenPrecedingEvent = new HashSet<>();
-		for (GKInstance inferrableEventInst : updatedInferrableHumanEvents)
-		{
-			if (!seenPrecedingEvent.contains(inferrableEventInst))
-			{
-				if (inferrableEventInst.getAttributeValue(precedingEvent)!= null)
-				{
+		for (GKInstance inferrableEventInst : updatedInferrableHumanEvents) {
+			if (!seenPrecedingEvent.contains(inferrableEventInst)) {
+				if (inferrableEventInst.getAttributeValue(precedingEvent) != null) {
 					logger.info("Adding preceding event to " + inferrableEventInst);
 					List<GKInstance> precedingEventInstances = new ArrayList<>();
 					// Find all preceding events for source instance that have an inferred counterpart
-					for (GKInstance precedingEventInst : (Collection<GKInstance>) inferrableEventInst.getAttributeValuesList(precedingEvent))
-					{
-						if (inferredEventIdenticals.get(precedingEventInst) != null)
-						{
+					for (GKInstance precedingEventInst : (Collection<GKInstance>) inferrableEventInst.getAttributeValuesList(precedingEvent)) {
+						if (inferredEventIdenticals.get(precedingEventInst) != null) {
 							precedingEventInstances.add(inferredEventIdenticals.get(precedingEventInst));
 						}
 					}
 					Set<String> inferredPrecedingEvents = new HashSet<>();
 					// Find any inferred preceding events that already exist for the inferred instance (don't want to add any redundant preceding events)
-					for (GKInstance precedingEventInst : (Collection<GKInstance>) inferredEventIdenticals.get(inferrableEventInst).getAttributeValuesList(precedingEvent))
-					{
+					for (GKInstance precedingEventInst : (Collection<GKInstance>) inferredEventIdenticals.get(inferrableEventInst).getAttributeValuesList(precedingEvent)) {
 						inferredPrecedingEvents.add(precedingEventInst.getDBID().toString());
 					}
 					List<GKInstance> updatedPrecedingEventInstances = new ArrayList<>();
 					// Find existing preceding events that haven't already been attached to the inferred instance
-					for (GKInstance precedingEventInst : precedingEventInstances)
-					{
-						if (!inferredPrecedingEvents.contains(precedingEventInst.getDBID().toString()))
-						{
+					for (GKInstance precedingEventInst : precedingEventInstances) {
+						if (!inferredPrecedingEvents.contains(precedingEventInst.getDBID().toString())) {
 							updatedPrecedingEventInstances.add(precedingEventInst);
 						}
 					}
 					// Add preceding event to inferred instance
-					if (updatedPrecedingEventInstances != null && updatedPrecedingEventInstances.size() > 0)
-					{
+					if (updatedPrecedingEventInstances != null && updatedPrecedingEventInstances.size() > 0) {
 						inferredEventIdenticals.get(inferrableEventInst).addAttributeValue(precedingEvent, updatedPrecedingEventInstances);
 						dba.updateInstanceAttribute(inferredEventIdenticals.get(inferrableEventInst), precedingEvent);
 					}

--- a/orthoinference/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
@@ -293,13 +293,15 @@ public class ReactionInferrer {
 		summationInst = summationInstCopy;
 	}
 	
-	public static Map<GKInstance, GKInstance> getInferredEvent()
+	public static Map<GKInstance, GKInstance> getInferredEvent(Map<GKInstance, GKInstance> eventsAlreadyInferredMap)
 	{
+		inferredEvent.putAll(eventsAlreadyInferredMap);
 		return inferredEvent;
 	}
 	
-	public static List<GKInstance> getInferrableHumanEvents()
+	public static List<GKInstance> getInferrableHumanEvents(List<GKInstance> eventsAlreadyInferred)
 	{
+		inferrableHumanEvents.addAll(eventsAlreadyInferred);
 		return inferrableHumanEvents;
 	}
 

--- a/orthoinference/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/ReactionInferrer.java
@@ -21,13 +21,11 @@ public class ReactionInferrer {
 	private static final Logger logger = LogManager.getLogger();
 	private static MySQLAdaptor dba;
 	private static String dateOfRelease = "";
-	private static String eligibleFilehandle;
 	private static String inferredFilehandle;
 	private static GKInstance summationInst;
 	private static GKInstance evidenceTypeInst;
 	private static Map<GKInstance, GKInstance> inferredCatalyst = new HashMap<>();
 	private static Map<GKInstance, GKInstance> inferredEvent = new HashMap<>();
-	private static Integer eligibleCount = 0;
 	private static Integer inferredCount = 0;
 	private static List<GKInstance> inferrableHumanEvents = new ArrayList<>();
 	
@@ -44,6 +42,7 @@ public class ReactionInferrer {
 		if (inferredEvent.get(reactionInst) == null)
 		{
 			///// The beginning of an inference process:
+
 			// Creates inferred instance of reaction.
 			GKInstance infReactionInst = InstanceUtilities.createNewInferredGKInstance(reactionInst);
 			infReactionInst.addAttributeValue(name, reactionInst.getAttributeValuesList(name));
@@ -52,87 +51,72 @@ public class ReactionInferrer {
 			infReactionInst.addAttributeValue(evidenceType, evidenceTypeInst);
 			infReactionInst.addAttributeValue(_displayName, reactionInst.getAttributeValue(_displayName));
 
-			// This function finds the total number of distinct proteins associated with an instance, as well as the number that can be inferred.
-			// Total proteins are stored in reactionProteinCounts[0], inferrable proteins in [1], and the maximum number of homologues for any entity involved in index [2].
-			// Reactions with no proteins/EWAS (Total = 0) are not inferred.
-			List<Integer> reactionProteinCounts = ProteinCountUtility.getDistinctProteinCounts(reactionInst);
-			int reactionTotalProteinCounts = reactionProteinCounts.get(0);
-			if (reactionTotalProteinCounts > 0) 
+			// Attempt to infer all PhysicalEntities associated with this reaction's Input, Output, CatalystActivity and RegulatedBy attributes.
+			// Failure to successfully infer any of these attributes will end inference for this reaction.
+			logger.info("Inferring inputs...");
+			if (inferReactionInputsOrOutputs(reactionInst, infReactionInst, input))
 			{
-				logger.info("Total protein count for RlE: " + reactionTotalProteinCounts);
-				String eligibleEventName = reactionInst.getAttributeValue(DB_ID).toString() + "\t" + reactionInst.getDisplayName() + "\n";	
-				// Having passed all tests/filters until now, the reaction is recorded in the 'eligible reactions' file, meaning inference is continued.
-				eligibleCount++;
-				Files.write(Paths.get(eligibleFilehandle), eligibleEventName.getBytes(), StandardOpenOption.APPEND);
-				// Attempt to infer all PhysicalEntities associated with this reaction's Input, Output, CatalystActivity and RegulatedBy attributes.
-				// Failure to successfully infer any of these attributes will end inference for this reaction.
-				logger.info("Inferring inputs...");
-				if (inferReactionInputsOrOutputs(reactionInst, infReactionInst, input))
+				logger.info("Inferring outputs...");
+				if (inferReactionInputsOrOutputs(reactionInst, infReactionInst, output))
 				{
-					logger.info("Inferring outputs...");
-					if (inferReactionInputsOrOutputs(reactionInst, infReactionInst, output))
+					logger.info("Inferring catalysts...");
+					if (inferReactionCatalysts(reactionInst, infReactionInst))
 					{
-						logger.info("Inferring catalysts...");
-						if (inferReactionCatalysts(reactionInst, infReactionInst))
+						// Many reactions are not regulated at all, meaning inference is attempted but will not end the process if there is nothing to infer.
+						// The inference process will end though if inferRegulations returns an invalid value.
+						logger.info("Inferring regulations...");
+						List<GKInstance> inferredRegulations = inferReactionRegulations(reactionInst);
+						if (inferredRegulations.size() == 1 && inferredRegulations.get(0) == null)
 						{
-							// Many reactions are not regulated at all, meaning inference is attempted but will not end the process if there is nothing to infer. 
-							// The inference process will end though if inferRegulations returns an invalid value.
-							logger.info("Inferring regulations...");
-							List<GKInstance> inferredRegulations = inferReactionRegulations(reactionInst);
-							if (inferredRegulations.size() == 1 && inferredRegulations.get(0) == null)
-							{
-								return;
-							}
-							if (infReactionInst.getSchemClass().isValidAttribute(releaseDate)) 
-							{
-								infReactionInst.addAttributeValue(releaseDate, dateOfRelease);
-							}
-							// FetchIdenticalInstances would just return the instance being inferred. Since this step is meant to always
-							// add a new inferred instance, the storeInstance method is just called here.
-							GKInstance orthoStableIdentifierInst = EventsInferrer.getStableIdentifierGenerator().generateOrthologousStableId(infReactionInst, reactionInst);
-							infReactionInst.addAttributeValue(stableIdentifier, orthoStableIdentifierInst);
-							dba.storeInstance(infReactionInst);
-							logger.info("Inferred RlE instance: " + infReactionInst);
-
-							if (infReactionInst.getSchemClass().isValidAttribute(inferredFrom))
-							{
-								infReactionInst = InstanceUtilities.addAttributeValueIfNecessary(infReactionInst, reactionInst, inferredFrom);
-								dba.updateInstanceAttribute(infReactionInst, inferredFrom);
-							}
-							infReactionInst = InstanceUtilities.addAttributeValueIfNecessary(infReactionInst, reactionInst, orthologousEvent);
-							dba.updateInstanceAttribute(infReactionInst, orthologousEvent);
-							reactionInst.addAttributeValue(orthologousEvent, infReactionInst);
-							dba.updateInstanceAttribute(reactionInst, orthologousEvent);
-							
-							inferredEvent.put(reactionInst, infReactionInst);
-							
-							// Regulations instances require the DB to contain the inferred ReactionlikeEvent, so Regulations inference happens post-inference
-							if (inferredRegulations.size() > 0)
-							{
-								logger.info("Number of regulator(s) inferred: " + inferredRegulations.size());
-								for (GKInstance infRegulation : inferredRegulations)
-								{
-									infRegulation = InstanceUtilities.checkForIdenticalInstances(infRegulation, null);
-									infReactionInst.addAttributeValue("regulatedBy", infRegulation);
-									dba.updateInstanceAttribute(infReactionInst, "regulatedBy");
-								}
-							}
-							// After successfully adding a new inferred instance to the DB, it is recorded in the 'inferred reactions' file
-							inferredCount++;
-							inferrableHumanEvents.add(reactionInst);
-							String inferredEvent = infReactionInst.getAttributeValue(DB_ID).toString() + "\t" + infReactionInst.getDisplayName() + "\n";	
-							Files.write(Paths.get(inferredFilehandle), inferredEvent.getBytes(), StandardOpenOption.APPEND);
-						} else {
-							logger.info("Catalyst inference unsuccessful -- terminating inference for " + reactionInst);
+							return;
 						}
+						if (infReactionInst.getSchemClass().isValidAttribute(releaseDate))
+						{
+							infReactionInst.addAttributeValue(releaseDate, dateOfRelease);
+						}
+						// FetchIdenticalInstances would just return the instance being inferred. Since this step is meant to always
+						// add a new inferred instance, the storeInstance method is just called here.
+						GKInstance orthoStableIdentifierInst = EventsInferrer.getStableIdentifierGenerator().generateOrthologousStableId(infReactionInst, reactionInst);
+						infReactionInst.addAttributeValue(stableIdentifier, orthoStableIdentifierInst);
+						dba.storeInstance(infReactionInst);
+						logger.info("Inferred RlE instance: " + infReactionInst);
+
+						if (infReactionInst.getSchemClass().isValidAttribute(inferredFrom))
+						{
+							infReactionInst = InstanceUtilities.addAttributeValueIfNecessary(infReactionInst, reactionInst, inferredFrom);
+							dba.updateInstanceAttribute(infReactionInst, inferredFrom);
+						}
+						infReactionInst = InstanceUtilities.addAttributeValueIfNecessary(infReactionInst, reactionInst, orthologousEvent);
+						dba.updateInstanceAttribute(infReactionInst, orthologousEvent);
+						reactionInst.addAttributeValue(orthologousEvent, infReactionInst);
+						dba.updateInstanceAttribute(reactionInst, orthologousEvent);
+
+						inferredEvent.put(reactionInst, infReactionInst);
+
+						// Regulations instances require the DB to contain the inferred ReactionlikeEvent, so Regulations inference happens post-inference
+						if (inferredRegulations.size() > 0)
+						{
+							logger.info("Number of regulator(s) inferred: " + inferredRegulations.size());
+							for (GKInstance infRegulation : inferredRegulations)
+							{
+								infRegulation = InstanceUtilities.checkForIdenticalInstances(infRegulation, null);
+								infReactionInst.addAttributeValue("regulatedBy", infRegulation);
+								dba.updateInstanceAttribute(infReactionInst, "regulatedBy");
+							}
+						}
+						// After successfully adding a new inferred instance to the DB, it is recorded in the 'inferred reactions' file
+						inferredCount++;
+						inferrableHumanEvents.add(reactionInst);
+						String inferredEvent = infReactionInst.getAttributeValue(DB_ID).toString() + "\t" + infReactionInst.getDisplayName() + "\n";
+						Files.write(Paths.get(inferredFilehandle), inferredEvent.getBytes(), StandardOpenOption.APPEND);
 					} else {
-						logger.info("Output inference unsuccessful -- terminating inference for " + reactionInst);
+						logger.info("Catalyst inference unsuccessful -- terminating inference for " + reactionInst);
 					}
 				} else {
-					logger.info("Input inference unsuccessful -- terminating inference for " + reactionInst);
+					logger.info("Output inference unsuccessful -- terminating inference for " + reactionInst);
 				}
 			} else {
-				logger.info("No distinct proteins found in instance -- terminating inference for " + reactionInst);
+				logger.info("Input inference unsuccessful -- terminating inference for " + reactionInst);
 			}
 		}
 	}
@@ -273,11 +257,6 @@ public class ReactionInferrer {
 		dba = dbAdaptor;
 	}
 	
-	public static void setEligibleFilename(String eligibleFilename)
-	{
-		eligibleFilehandle = eligibleFilename;
-	}
-	
 	public static void setInferredFilename(String inferredFilename)
 	{
 		inferredFilehandle = inferredFilename;
@@ -303,11 +282,6 @@ public class ReactionInferrer {
 	{
 		inferrableHumanEvents.addAll(eventsAlreadyInferred);
 		return inferrableHumanEvents;
-	}
-
-	public static int getEligibleCount()
-	{
-		return eligibleCount;
 	}
 	
 	public static int getInferredCount()

--- a/orthoinference/src/main/java/org/reactome/orthoinference/SkipInstanceChecker.java
+++ b/orthoinference/src/main/java/org/reactome/orthoinference/SkipInstanceChecker.java
@@ -111,27 +111,42 @@ public class SkipInstanceChecker {
 	private static boolean reactionComponentsAreInferrable(GKInstance reactionInst) throws Exception {
 		Collection<GKInstance> reactionComponents = reactionInst.getAttributeValuesList(input);
 		reactionComponents.addAll(reactionInst.getAttributeValuesList(output));
+		Collection<GKInstance> reactionCatalysts = reactionInst.getAttributeValuesList(catalystActivity);
+		for (GKInstance reactionCatalyst : reactionCatalysts) {
+			GKInstance catalystPE = (GKInstance) reactionCatalyst.getAttributeValue(physicalEntity);
+			if (catalystPE != null) {
+				reactionComponents.add(catalystPE);
+			}
+		}
 		for (GKInstance reactionComponent : reactionComponents) {
 			if (!SpeciesCheckUtility.checkForSpeciesAttribute(reactionComponent)) {
-				return true;
-			} else if (reactionComponent.getSchemClass().toString().contains(EntityWithAccessionedSequence)) {
-				String referenceEntityId = ((GKInstance) reactionComponent.getAttributeValue(referenceEntity)).getAttributeValue(identifier).toString();
-				if (homologueMappings.get(referenceEntityId) == null) {
+//				return true;
+			} else if (reactionComponent.getSchemClass().isa(GenomeEncodedEntity))
+			{
+				if (reactionComponent.getSchemClass().toString().contains(EntityWithAccessionedSequence)) {
+					String referenceEntityId = ((GKInstance) reactionComponent.getAttributeValue(referenceEntity)).getAttributeValue(identifier).toString();
+					if (homologueMappings.get(referenceEntityId) == null) {
+						return false;
+					}
+				} else {
 					return false;
 				}
-			} else if (reactionComponent.getSchemClass().isa(Complex) || reactionComponent.getSchemClass().isa(Polymer)) {
+			} else if (reactionComponent.getSchemClass().isa(Complex) || reactionComponent.getSchemClass().isa(Polymer) || reactionComponent.getSchemClass().isa(EntitySet)) {
 				System.out.println(reactionComponent);
 				List<Integer> complexProteinCounts = ProteinCountUtility.getDistinctProteinCounts(reactionComponent);
-				int complexTotalProteinCounts = complexProteinCounts.get(0);
-				int complexInferrableProteinCounts = complexProteinCounts.get(1);
-				int percent = 0;
-				if (complexTotalProteinCounts > 0)
-				{
-					percent = (complexInferrableProteinCounts * 100)/complexTotalProteinCounts;
-				}
-				if (percent < 75)
-				{
-					logger.info("Complex/Polymer protein count is below 75% threshold (" + percent + "%) -- terminating inference");
+				int totalProteinCounts = complexProteinCounts.get(0);
+				int inferrableProteinCounts = complexProteinCounts.get(1);
+				if (reactionComponent.getSchemClass().isa(Complex) || reactionComponent.getSchemClass().isa(Polymer)) {
+					int percent = 0;
+					if (totalProteinCounts > 0) {
+						percent = (inferrableProteinCounts * 100) / totalProteinCounts;
+					}
+					if (percent < 75) {
+						logger.info("Complex/Polymer protein count is below 75% threshold (" + percent + "%) -- terminating inference");
+						return false;
+					}
+				} else if (totalProteinCounts > 0 && inferrableProteinCounts == 0) {
+					logger.info("No distinct proteins found in EntitySet -- terminating inference");
 					return false;
 				}
 			}


### PR DESCRIPTION
This PR addresses a couple of things that had been on the backburner for Orthoinference:

1) _Most_ PhysicalEntity instances are now screened before any inference is attempted on a ReactionlikeEvent. The only cases that aren't screened ahead of time are some edge cases for EntitySets that were very difficult to isolate out ahead of time. Safeguards still exist for preventing inference, so the ones that do squeak through this new screening system will still be rejected. This will prevent a significant majority of orphan PEs.

2) Orthoinference is now interruptable. If the process is stopped in the middle of a species' inference, it can be restarted and it will still create Pathways and PathwayDiagrams for any _automatically_ inferred RlEs. **A question**: Should manually inferred ones also be receiving Pathway and PathwayDiagram instances? Its a very simple adjustment if so. This addresses #31 

3) The report file produced at the end of a species' inference now has a header that denotes the release. This addresses #83 

Thanks!