### PR TITLE
Feature/post step test other identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,14 +30,22 @@ hs_err_pid*
 RemoteSystemsTempFiles
 update-dois/target/maven-status/maven-compiler-plugin/compile/default-compile/*.lst
 update-dois/.settings/org.eclipse.jdt.core.prefs
-config.properties
 *.classpath
 *.project
 .settings
 target
 *.report
 .attach_pid*
+
+## Release-specific files
 normal_event_skip_list.txt
+config.properties
+orthoinference*out
+GENES_RAT.txt
+GenePageEnsemblModelMapping.txt
+HGNC_homologene.rpt
+ensembl_1_to_1.txt
+doisToBeUpdated-v*.txt
 
 logs/
 \.idea/

--- a/other-identifiers/pom.xml
+++ b/other-identifiers/pom.xml
@@ -13,8 +13,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>7</source>
-                    <target>7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/other-identifiers/pom.xml
+++ b/other-identifiers/pom.xml
@@ -39,6 +39,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.5.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>2.1</version>

--- a/other-identifiers/pom.xml
+++ b/other-identifiers/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.reactome.release</groupId>
+    <artifactId>otherIdentifiers</artifactId>
+    <version>0.0.1</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>7</source>
+                    <target>7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.reactome.release</groupId>
+            <artifactId>release-common-lib</artifactId>
+            <version>1.1.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/other-identifiers/pom.xml
+++ b/other-identifiers/pom.xml
@@ -31,6 +31,31 @@
             <artifactId>release-common-lib</artifactId>
             <version>1.1.1-SNAPSHOT</version>
         </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/Main.java
+++ b/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/Main.java
@@ -1,0 +1,41 @@
+package org.reactome.release.otherIdentifiers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.gk.persistence.MySQLAdaptor;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class Main {
+
+    private static final Logger logger = LogManager.getLogger();
+    private static final String RESOURCES_DIR = Paths.get("src", "main", "resources").toString();
+
+    public static void main(String[] args) throws IOException, SQLException {
+
+        String pathToConfig = args.length > 0 ? args[0] : Paths.get(RESOURCES_DIR ,"config.properties").toString();
+
+        Properties props = new Properties();
+        props.load(new FileInputStream(pathToConfig));
+
+        //Set up DB adaptor
+        String username = props.getProperty("release.database.user");
+        String password = props.getProperty("release.database.password");
+        String host = props.getProperty("release.database.host");
+        int port = Integer.valueOf(props.getProperty("release.database.port"));
+
+        String releaseCurrent = props.getProperty("release_current.name");
+        String releasePrevious = props.getProperty("release_previous.name");
+
+        MySQLAdaptor dbAdaptor = new MySQLAdaptor(host, releaseCurrent, username, password, port);
+        MySQLAdaptor dbAdaptorPrev = new MySQLAdaptor(host, releasePrevious, username, password, port);
+
+        logger.info("Executing post-step checks");
+        PostStepChecks.compareOtherIdentifierCounts();
+
+    }
+}

--- a/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/Main.java
+++ b/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/Main.java
@@ -15,7 +15,7 @@ public class Main {
     private static final Logger logger = LogManager.getLogger();
     private static final String RESOURCES_DIR = Paths.get("src", "main", "resources").toString();
 
-    public static void main(String[] args) throws IOException, SQLException {
+    public static void main(String[] args) throws Exception {
 
         String pathToConfig = args.length > 0 ? args[0] : Paths.get(RESOURCES_DIR ,"config.properties").toString();
 
@@ -35,7 +35,7 @@ public class Main {
         MySQLAdaptor dbAdaptorPrev = new MySQLAdaptor(host, releasePrevious, username, password, port);
 
         logger.info("Executing post-step checks");
-        PostStepChecks.compareOtherIdentifierCounts();
+        PostStepChecks.compareOtherIdentifierCounts(dbAdaptor, dbAdaptorPrev);
 
     }
 }

--- a/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/Main.java
+++ b/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/Main.java
@@ -5,9 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.gk.persistence.MySQLAdaptor;
 
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.nio.file.Paths;
-import java.sql.SQLException;
 import java.util.Properties;
 
 public class Main {

--- a/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/PostStepChecks.java
+++ b/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/PostStepChecks.java
@@ -9,6 +9,13 @@ import org.gk.persistence.MySQLAdaptor;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ *  This is a QA step that will be run after finishing an OtherIdentifiers run. For each species,
+ *  the count of ReferenceGeneProduct instances that have their 'otherIdentifier' attribute filled is found
+ *  between the current and previous database. If the previous database has a higher count, a warning message
+ *  is output and should be looked into. If the count is still relatively close,  it can probably be ignored.
+ */
+
 public class PostStepChecks {
     private static final Logger logger = LogManager.getLogger();
 
@@ -17,20 +24,36 @@ public class PostStepChecks {
         Collection<GKInstance> speciesInstances = dba.fetchInstancesByClass(ReactomeJavaConstants.Species);
 
         for (GKInstance speciesInstance : speciesInstances) {
-            int currentOtherIdentifierCount = getOtherIdentifierCount(dba, speciesInstance);
-            int previousOtherIdentifierCount = getOtherIdentifierCount(dbaPrev, speciesInstance);
+            int currentOtherIdentifierCount = getRGPInstanceOtherIdentifierCount(dba, speciesInstance);
+            int previousOtherIdentifierCount = getRGPInstanceOtherIdentifierCount(dbaPrev, speciesInstance);
             if (currentOtherIdentifierCount < previousOtherIdentifierCount) {
                 logger.warn(speciesInstance.getDisplayName() + " has fewer ReferenceGeneProduct instances with OtherIdentifiers compared to previous release:  " +
                         "release_current - " + currentOtherIdentifierCount + " -- release_previous - " + previousOtherIdentifierCount);
             }
         }
-
-
     }
 
-    private static int getOtherIdentifierCount(MySQLAdaptor dba, GKInstance speciesInstance) throws Exception {
-        AtomicInteger currentOtherIdentifierCount = new AtomicInteger();
+    /**
+     * Wrapper method for determining other identifier count.
+     * @param dba MySQLAdaptor
+     * @param speciesInstance GKInstance pertaining to a specific species
+     * @return The other identifier count, as an int.
+     * @throws Exception
+     */
+    private static int getRGPInstanceOtherIdentifierCount(MySQLAdaptor dba, GKInstance speciesInstance) throws Exception {
         Collection<GKInstance> rgpInstances = dba.fetchInstanceByAttribute(ReactomeJavaConstants.ReferenceGeneProduct, ReactomeJavaConstants.species, "=", speciesInstance);
+
+        int currentOtherIdentifierCount = getOtherIdentifierCount(rgpInstances);
+        return currentOtherIdentifierCount;
+    }
+
+    /**
+     * Determines the number of ReferenceGeneProduct instances that have a filled otherIdentifier attribute.
+     * @param rgpInstances Collection of RGP GKInstances associated with a species.
+     * @return An int is returned, representing the otherIdentifier count.
+     */
+    public static int getOtherIdentifierCount(Collection<GKInstance> rgpInstances) {
+        AtomicInteger currentOtherIdentifierCount = new AtomicInteger();
         rgpInstances.forEach(rgpInstance -> {
             try {
                 if (rgpInstance.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier).size() > 0) {

--- a/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/PostStepChecks.java
+++ b/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/PostStepChecks.java
@@ -2,10 +2,44 @@ package org.reactome.release.otherIdentifiers;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.gk.model.GKInstance;
+import org.gk.model.ReactomeJavaConstants;
+import org.gk.persistence.MySQLAdaptor;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class PostStepChecks {
     private static final Logger logger = LogManager.getLogger();
 
-    public static void compareOtherIdentifierCounts() {
+    public static void compareOtherIdentifierCounts(MySQLAdaptor dba, MySQLAdaptor dbaPrev) throws Exception {
+
+        Collection<GKInstance> speciesInstances = dba.fetchInstancesByClass(ReactomeJavaConstants.Species);
+
+        for (GKInstance speciesInstance : speciesInstances) {
+            int currentOtherIdentifierCount = getOtherIdentifierCount(dba, speciesInstance);
+            int previousOtherIdentifierCount = getOtherIdentifierCount(dbaPrev, speciesInstance);
+            if (currentOtherIdentifierCount < previousOtherIdentifierCount) {
+                logger.warn(speciesInstance.getDisplayName() + " has fewer ReferenceGeneProduct instances with OtherIdentifiers compared to previous release:  " +
+                        "release_current - " + currentOtherIdentifierCount + " -- release_previous - " + previousOtherIdentifierCount);
+            }
+        }
+
+
+    }
+
+    private static int getOtherIdentifierCount(MySQLAdaptor dba, GKInstance speciesInstance) throws Exception {
+        AtomicInteger currentOtherIdentifierCount = new AtomicInteger();
+        Collection<GKInstance> rgpInstances = dba.fetchInstanceByAttribute(ReactomeJavaConstants.ReferenceGeneProduct, ReactomeJavaConstants.species, "=", speciesInstance);
+        rgpInstances.forEach(rgpInstance -> {
+            try {
+                if (rgpInstance.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier).size() > 0) {
+                    currentOtherIdentifierCount.getAndIncrement();
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        return currentOtherIdentifierCount.intValue();
     }
 }

--- a/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/PostStepChecks.java
+++ b/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/PostStepChecks.java
@@ -1,0 +1,11 @@
+package org.reactome.release.otherIdentifiers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PostStepChecks {
+    private static final Logger logger = LogManager.getLogger();
+
+    public static void compareOtherIdentifierCounts() {
+    }
+}

--- a/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/PostStepChecks.java
+++ b/other-identifiers/src/main/java/org/reactome/release/otherIdentifiers/PostStepChecks.java
@@ -46,11 +46,11 @@ public class PostStepChecks {
      * @param dba MySQLAdaptor
      * @param speciesInstance GKInstance pertaining to a specific species
      * @return The other identifier count, as an int.
-     * @throws Exception can be caused by errors interacting with the database using the db adaptor.
+     * @throws Exception can be caused by errors when attempting to retrieve ReferenceGeneProduct instances from the database.
      */
     private static long getRGPInstanceOtherIdentifierCount(MySQLAdaptor dba, GKInstance speciesInstance) throws Exception {
-        Collection<GKInstance> rgpInstances = dba.fetchInstanceByAttribute(ReactomeJavaConstants.ReferenceGeneProduct, ReactomeJavaConstants.species, "=", speciesInstance);
-        return getCountOfInstancesWithOtherIdentifiers(rgpInstances);
+            Collection<GKInstance> rgpInstances = dba.fetchInstanceByAttribute(ReactomeJavaConstants.ReferenceGeneProduct, ReactomeJavaConstants.species, "=", speciesInstance);
+            return getCountOfInstancesWithOtherIdentifiers(rgpInstances);
     }
 
     /**

--- a/other-identifiers/src/main/resources/config.properties
+++ b/other-identifiers/src/main/resources/config.properties
@@ -1,0 +1,8 @@
+
+release.database.user=
+release.database.password=
+release.database.host=
+release.database.port=
+
+release_current.name=release_current
+release_previous.name=release_previous

--- a/other-identifiers/src/main/resources/config.properties
+++ b/other-identifiers/src/main/resources/config.properties
@@ -2,7 +2,7 @@
 release.database.user=
 release.database.password=
 release.database.host=
-release.database.port=
+release.database.port=3306
 
 release_current.name=release_current
 release_previous.name=release_previous

--- a/other-identifiers/src/main/resources/log4j2.xml
+++ b/other-identifiers/src/main/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+        </Console>
+        <RollingFile name="LogFile" fileName="logs/OtherIdentifiers-${date:MM-dd-yyyy_HH.mm.ss}.log" filePattern="logs/OtherIdentifiers-%d{MM-dd-yyyy_HH.mm.ss}.log">
+            <PatternLayout>
+                <Pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy />
+            </Policies>
+        </RollingFile>
+        <RollingFile name="warningsLogFile" fileName="logs/OtherIdentifiers-${date:MM-dd-yyyy_HH.mm.ss}.err" filePattern="logs/OtherIdentifiers-%d{MM-dd-yyyy_HH.mm.ss}.err">
+            <PatternLayout>
+                <Pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy />
+            </Policies>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <Logger name="warningsLog" level="warn" additivity="false">
+            <AppenderRef ref="warningsLogFile"/>
+        </Logger>
+        <Root level="debug">
+            <AppenderRef ref="Console" level="debug"/>
+            <AppenderRef ref="LogFile" level="info"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/other-identifiers/src/test/java/org/reactome/release/otherIdentifiers/PostStepChecksTest.java
+++ b/other-identifiers/src/test/java/org/reactome/release/otherIdentifiers/PostStepChecksTest.java
@@ -10,13 +10,14 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PostStepChecks.class})
@@ -65,22 +66,18 @@ public class PostStepChecksTest {
 
     @Test
     public void getCountOfInstancesWithOtherIdentifiersNullTest() {
-        try {
-            long otherIdentifierCount = PostStepChecks.getCountOfInstancesWithOtherIdentifiers(null);
-        } catch (Exception e) {
-            e.printStackTrace();
-            assertTrue(e.toString().contains("NullPointerException"));
-        }
+        NullPointerException thrown = assertThrows(
+                NullPointerException.class,
+                () -> PostStepChecks.getCountOfInstancesWithOtherIdentifiers(null));
+        assertThat(thrown.toString(), containsString("NullPointerException"));
     }
 
     @Test
     public void hasOtherIdentifiersNullTest() {
-        try {
-            PostStepChecks.hasOtherIdentifiers(null);
-        } catch(Exception e) {
-            e.printStackTrace();
-            assertTrue(e.getMessage().equals("Unable to retrieve other identifiers from RGP instance null"));
-        }
+            RuntimeException thrown = assertThrows(
+                    RuntimeException.class,
+                    () -> PostStepChecks.hasOtherIdentifiers(null));
+            assertThat(thrown.getMessage(), containsString("Unable to retrieve other identifiers from RGP instance"));
     }
 
     @Test

--- a/other-identifiers/src/test/java/org/reactome/release/otherIdentifiers/PostStepChecksTest.java
+++ b/other-identifiers/src/test/java/org/reactome/release/otherIdentifiers/PostStepChecksTest.java
@@ -1,0 +1,45 @@
+package org.reactome.release.otherIdentifiers;
+
+import org.gk.model.GKInstance;
+import org.gk.model.ReactomeJavaConstants;
+import org.gk.persistence.MySQLAdaptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PostStepChecks.class})
+@PowerMockIgnore({"org.apache.logging.log4j.*", "javax.management.*", "javax.script.*",
+        "javax.xml.*", "com.sun.org.apache.xerces.*", "org.xml.sax.*", "com.sun.xml.*", "org.w3c.dom.*", "org.mockito.*"})
+public class PostStepChecksTest {
+
+    private final int correctOtherIdentifierCount = 2;
+
+    @Mock
+    GKInstance mockGKInstance;
+
+    Collection<GKInstance> gkInstanceCollection = new ArrayList<>();
+    List<Object> otherIdentifierCollection = new ArrayList<>();
+
+    @Test
+    public void getOtherIdentifierCountReturnsAtomicInt() throws Exception {
+
+        gkInstanceCollection.add(mockGKInstance);
+        gkInstanceCollection.add(mockGKInstance);
+        otherIdentifierCollection.add("Mock otherIdentifier");
+        Mockito.when(mockGKInstance.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier)).thenReturn(otherIdentifierCollection);
+        int otherIdentifierCount = PostStepChecks.getOtherIdentifierCount(gkInstanceCollection);
+        assertThat(otherIdentifierCount, is(equalTo(correctOtherIdentifierCount)));
+    }
+}


### PR DESCRIPTION
This is actually just a PR for the other identifiers work. Stable Id History post-step code will be in another PR.

Simple post-step check for Other Identifiers. For each species in the database, count the number of ReferenceGeneProduct instances that have their 'otherIdentifier' slot filled. Compare this count with the same count done on the previous database and report if there is less.

Please suggest other unit tests if you can think of any.